### PR TITLE
Supporting SMART on FHIR patient scopes in PatientAccessChecker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN mvn --batch-mode package -Pstandalone-app -Dlicense.skip=true
 # Image for FHIR Access Proxy binary with configuration knobs as environment vars.
 FROM eclipse-temurin:11-jdk-focal as main
 
-COPY --from=build /app/exec/target/exec-0.1.0.jar /
+COPY --from=build /app/exec/target/exec-0.1.1.jar /
 COPY resources/hapi_page_url_allowed_queries.json resources/hapi_page_url_allowed_queries.json
 
 ENV PROXY_PORT=8080
@@ -54,4 +54,4 @@ ENV BACKEND_TYPE="HAPI"
 ENV ACCESS_CHECKER="list"
 ENV RUN_MODE="PROD"
 
-ENTRYPOINT java -jar exec-0.1.0.jar --server.port=${PROXY_PORT}
+ENTRYPOINT java -jar exec-0.1.1.jar --server.port=${PROXY_PORT}

--- a/doc/design.md
+++ b/doc/design.md
@@ -23,54 +23,50 @@ first version (V1) of the FHIR gateway:
 
 <img src="summary.png" width=50% height=50%>
 
-*   There are three main components responsible for access decisions: an
-    Identity Provider (IDP) which authenticates the user, an Authorization
-    server (AuthZ) that decides what a given user can access and an Access
-    Gateway which enforces those permissions. We are implementing the access
-    gateway.
-*   The gateway has two main components: (i) a core "_server_" piece which
-    provides the servlets, interceptors, FHIR query processor, and other common
-    pieces to any access-control strategy and (ii) a customizable
-    `AccessChecker` "_plugin_".
-*   The authorization flow is based on the "authorization code flow" of OAuth
-    2.0. This resembles [SMART on FHIR
-    spec](http://www.hl7.org/fhir/smart-app-launch/) (SoF) but is not limited to
-    it. In particular, some access-checker plugins may rely on extra claims in
-    the access token not defined in SoF.  We did this because the access
-    controls captured in SoF did not seem sufficiently expressive for a lot of
-    use cases we have observed.
-*   We currently provide two example, default plugins: one that supports parts
-    of the SoF spec for patient context/scopes and one that is a simple
-    list-based access-checker.
-*   For access control rules, a plugin can choose to implement anything but
-    there is some functionality provided out-of-the-box by the server code that
-    should cover many cases:
-    *   For FHIR queries scoped to a single (or group of) patients, there is a
-        library to extract referenced patient(s) from the query/resources, based
-        on the [Patient
-        Compartment](https://hl7.org/fhir/compartmentdefinition-patient.html)
-        definition. The expectation is that most access-control rules come down
-        to deciding whether the user has access to that patient data or not. The
-        plugin makes this decision.
-    *   For searches beyond patient boundaries, define a set of templates to
-        allow or reject access based on the query string (i.e., the "_allow
-        list_").
-*   We assume that the IDP+AuthZ together establish the user's identity and
-    access rules in a token of
-    [JWT](https://en.wikipedia.org/wiki/JSON_Web_Token) type. This "access
-    token" should accompany requests to the gateway.
-*   The gateway will be implemented using HAPI FHIR libraries and is the main
-    focus of this design doc.
-*   The authorization server may implement authentication too or it may rely on
-    a separate authentication service that supports [OpenID Connect
-    spec](https://openid.net/connect/). Those details are beyond this design
-    doc.
-*   The server and plugin parts of the gateway will be released as libraries and
-    there would also be a sample "main" Spring Boot application which packages
-    everything in a single executable jar. This is easily deployable as a docker
-    container too.
+- There are three main components responsible for access decisions: an Identity
+  Provider (IDP) which authenticates the user, an Authorization server (AuthZ)
+  that decides what a given user can access and an Access Gateway which enforces
+  those permissions. We are implementing the access gateway.
+- The gateway has two main components: (i) a core "_server_" piece which
+  provides the servlets, interceptors, FHIR query processor, and other common
+  pieces to any access-control strategy and (ii) a customizable `AccessChecker`
+  "_plugin_".
+- The authorization flow is based on the "authorization code flow" of OAuth 2.0.
+  This resembles [SMART on FHIR spec](http://www.hl7.org/fhir/smart-app-launch/)
+  (SoF) but is not limited to it. In particular, some access-checker plugins may
+  rely on extra claims in the access token not defined in SoF. We did this
+  because the access controls captured in SoF did not seem sufficiently
+  expressive for a lot of use cases we have observed.
+- We currently provide two example, default plugins: one that supports parts of
+  the SoF spec for patient context/scopes and one that is a simple list-based
+  access-checker.
+- For access control rules, a plugin can choose to implement anything but there
+  is some functionality provided out-of-the-box by the server code that should
+  cover many cases:
+  - For FHIR queries scoped to a single (or group of) patients, there is a
+    library to extract referenced patient(s) from the query/resources, based on
+    the
+    [Patient Compartment](https://hl7.org/fhir/compartmentdefinition-patient.html)
+    definition. The expectation is that most access-control rules come down to
+    deciding whether the user has access to that patient data or not. The plugin
+    makes this decision.
+  - For searches beyond patient boundaries, define a set of templates to allow
+    or reject access based on the query string (i.e., the "_allow list_").
+- We assume that the IDP+AuthZ together establish the user's identity and access
+  rules in a token of [JWT](https://en.wikipedia.org/wiki/JSON_Web_Token) type.
+  This "access token" should accompany requests to the gateway.
+- The gateway will be implemented using HAPI FHIR libraries and is the main
+  focus of this design doc.
+- The authorization server may implement authentication too or it may rely on a
+  separate authentication service that supports
+  [OpenID Connect spec](https://openid.net/connect/). Those details are beyond
+  this design doc.
+- The server and plugin parts of the gateway will be released as libraries and
+  there would also be a sample "main" Spring Boot application which packages
+  everything in a single executable jar. This is easily deployable as a docker
+  container too.
 
-##  Introduction
+## Introduction
 
 The context of this document is implementation of access controls for
 [FHIR](https://www.hl7.org/fhir/) resources. In particular, the focus is on web
@@ -80,11 +76,11 @@ from patients and needs to sync that data with a central FHIR store. While our
 design is meant to be generic, we want to have great support for apps built on
 top of the [Android FHIR SDK](https://github.com/google/android-fhir) ("the
 SDK"). Data collected by all CHWs is centralized in a backend FHIR store
-(a.k.a., _resource server_, e.g., a [GCP FHIR
-store](https://cloud.google.com/healthcare/docs/concepts/fhir) or a [HAPI FHIR
-server](https://hapifhir.io/)). The core issue is how to securely synchronize
-data between the FHIR store and the devices (the _data-sync_ problem). The
-security question has three main components:
+(a.k.a., _resource server_, e.g., a
+[GCP FHIR store](https://cloud.google.com/healthcare/docs/concepts/fhir) or a
+[HAPI FHIR server](https://hapifhir.io/)). The core issue is how to securely
+synchronize data between the FHIR store and the devices (the _data-sync_
+problem). The security question has three main components:
 
 1.  [**authentication**] Who the user is? How do we establish the identity of
     the end-user?
@@ -114,11 +110,10 @@ spec for two main reasons:
 
 Note that the more difficult part of the problem that we are trying to solve is
 access-control which is not directly addressed by SoF, as clearly stated in
-[section 3.0.1.1 of the current
-spec](https://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html#smarts-scopes-are-used-to-delegate-access):
+[section 3.0.1.1 of the current spec](https://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html#smarts-scopes-are-used-to-delegate-access):
 
->   "_Neither SMART on FHIR nor the FHIR Core specification provide a way to
-> model the "underlying" permissions at play here; this is a lower-level
+> "_Neither SMART on FHIR nor the FHIR Core specification provide a way to model
+> the "underlying" permissions at play here; this is a lower-level
 > responsibility in the access control stack. As such, clients can attempt to
 > perform FHIR operations based on the scopes they are granted — but depending
 > on the details of the underlying permission system (e.g., the permissions of
@@ -129,37 +124,37 @@ spec](https://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html#s
 
 Some of the main scenarios that need to be supported are:
 
-*   [**add-patient**] A HCW registers a new patient, this needs to be sent to
-    the FHIR server. The HCW might be offline at the time of registration.
-*   [**update-patient**] Patient data is updated, e.g., a new Observation is
-    added by a HCW. Again the HCW might be offline at the time of data entry and
-    many updates might be communicated to the backend FHIR store at the time of
-    server synchronization.
-*   [**fetch-my-patients**] A HCW needs all updates to their patients, e.g.,
-    because they have switched their device or another HCW has updated the same
-    patient's data.
-*   [**revoke-access**] Revoke a previously issued (and still valid)
-    access/refresh token.
-*   [**sof-apps**] It should be easy to support other SoF-based apps. For
-    example, a patient wants to browse their own data through a 3rd party
-    SoF-based app. For now, we limit this scenario to apps that only need
-    `patient/*` scopes.
+- [**add-patient**] A HCW registers a new patient, this needs to be sent to the
+  FHIR server. The HCW might be offline at the time of registration.
+- [**update-patient**] Patient data is updated, e.g., a new Observation is added
+  by a HCW. Again the HCW might be offline at the time of data entry and many
+  updates might be communicated to the backend FHIR store at the time of server
+  synchronization.
+- [**fetch-my-patients**] A HCW needs all updates to their patients, e.g.,
+  because they have switched their device or another HCW has updated the same
+  patient's data.
+- [**revoke-access**] Revoke a previously issued (and still valid)
+  access/refresh token.
+- [**sof-apps**] It should be easy to support other SoF-based apps. For example,
+  a patient wants to browse their own data through a 3rd party SoF-based app.
+  For now, we limit this scenario to apps that only need `patient/*` scopes.
 
 Constraints:
 
-*   [**flexible-access-control**] Enforce principle of least-privilege and
-    fine-grained access controls.  For example, a HCW should have access only to
-    their own patients.  A check could be implemented by  looking at patients
-    whose <code>[Patient](https://www.hl7.org/fhir/patient.html).generalPractitioner</code>
+- [**flexible-access-control**] Enforce principle of least-privilege and
+  fine-grained access controls. For example, a HCW should have access only to
+  their own patients. A check could be implemented by looking at patients whose
+  <code>[Patient](https://www.hl7.org/fhir/patient.html).generalPractitioner</code>
 
-    references that HCW; or are in the region assigned to that HCW (using
-    Location, Organization, CareTeam, etc.).  We may want to limit HCW's access
-    to some Observation types.
-*   [<strong>untrusted-app</strong>] The app cannot be assumed to be trusted; so
-    we should account for malicious access from the app; or abusing access
-    tokens issued for the app.
-*   [<strong>generalizable-design</strong>] The access gateway should be
-    independent of the specific FHIR server implementation, as much as possible.
+  references that HCW; or are in the region assigned to that HCW (using
+  Location, Organization, CareTeam, etc.). We may want to limit HCW's access to
+  some Observation types.
+
+- [<strong>untrusted-app</strong>] The app cannot be assumed to be trusted; so
+  we should account for malicious access from the app; or abusing access tokens
+  issued for the app.
+- [<strong>generalizable-design</strong>] The access gateway should be
+  independent of the specific FHIR server implementation, as much as possible.
 
 ## The high level design
 
@@ -170,29 +165,30 @@ accessing data. In subsequent sections we focus on the access gateway.
 
 Before going into details, let's clarify some terminology:
 
-*   **Client**: The mobile or web app requesting access to resources. In the
-    OAuth 2.0 sense, we mainly mean "public clients", i.e., there is no "client
-    secret" shared by the server.
-*   **Access token**: A string that can be used to access resources. While this
-    can be an "opaque" string, we use [JSON Web Token
-    (JWT)](https://en.wikipedia.org/wiki/JSON_Web_Token) throughout this design.
-    *   **Authorization flow**: Different ways for getting access tokens; our
-        main focus in this design is the "[authorization code
-        flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow)"
-        but without any client secrets.
-*   **Refresh token**: A token for fetching a new access token when the old one
-    expires.
-*   **Identity Provider (IDP)**: A [potentially shared] server to establish user
-    identity, e.g., Google, Twitter, GitHub, etc.
-*   **Authorization server**: A service that maps the user identity to some
-    access rules for FHIR store resources. In our design, this mapping is
-    recorded in the access token.
-*   **OpenID Connect**: An OAuth 2.0 based standard used by IDPs.
-*   **ID token**: A JWT issued by IDP proving the identity of the user
-*   **Claims**: Key-value pieces of information in JWTs
-*   **Scopes**: A set of predefined access rules to define what resources can be
-    accessed by an access token. These are represented as claims in the access
-    JWT.
+- **Client**: The mobile or web app requesting access to resources. In the OAuth
+  2.0 sense, we mainly mean "public clients", i.e., there is no "client secret"
+  shared by the server.
+- **Access token**: A string that can be used to access resources. While this
+  can be an "opaque" string, we use
+  [JSON Web Token (JWT)](https://en.wikipedia.org/wiki/JSON_Web_Token)
+  throughout this design.
+  - **Authorization flow**: Different ways for getting access tokens; our main
+    focus in this design is the
+    "[authorization code flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow)"
+    but without any client secrets.
+- **Refresh token**: A token for fetching a new access token when the old one
+  expires.
+- **Identity Provider (IDP)**: A [potentially shared] server to establish user
+  identity, e.g., Google, Twitter, GitHub, etc.
+- **Authorization server**: A service that maps the user identity to some access
+  rules for FHIR store resources. In our design, this mapping is recorded in the
+  access token.
+- **OpenID Connect**: An OAuth 2.0 based standard used by IDPs.
+- **ID token**: A JWT issued by IDP proving the identity of the user
+- **Claims**: Key-value pieces of information in JWTs
+- **Scopes**: A set of predefined access rules to define what resources can be
+  accessed by an access token. These are represented as claims in the access
+  JWT.
 
 In our overall design, we treat IDP and authorization server as one whole,
 sometimes referred to as the Identity and Access Management (IAM) or simply
@@ -212,19 +208,18 @@ is the access gateway, we keep this section brief. This is just to demonstrate
 the big picture and some best practices when deploying IDP and AuthZ servers.
 
 One of the recommended authorization flows and the one we consider here is the
-[Authorization Code
-Flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow).
+[Authorization Code Flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow).
 Since our main target is mobile (or single-page) apps that do not necessarily
-have a server side piece (a.k.a. "[public
-clients](https://oauth.net/2/client-types/)"), we consider the flow with no
-client secrets. This flow resembles [SMART on FHIR standalone app
-launch](https://www.hl7.org/fhir/smart-app-launch/app-launch.html#launch-app-standalone-launch)
+have a server side piece (a.k.a.
+"[public clients](https://oauth.net/2/client-types/)"), we consider the flow
+with no client secrets. This flow resembles
+[SMART on FHIR standalone app launch](https://www.hl7.org/fhir/smart-app-launch/app-launch.html#launch-app-standalone-launch)
 spec. There are at least three components we care about:
 
-*   the CHW app
-*   the auth service which is responsible for establishing the identity of the
-    user and authorizing access tokens.
-*   the FHIR resource server (e.g., GCP FHIR store or a HAPI FHIR server)
+- the CHW app
+- the auth service which is responsible for establishing the identity of the
+  user and authorizing access tokens.
+- the FHIR resource server (e.g., GCP FHIR store or a HAPI FHIR server)
 
 Here is a simplified view of the authorization sequence (note it is recommended
 to use
@@ -235,24 +230,24 @@ which is not shown in this diagram)[^1]:
 
 Here is a brief description of each step:
 
-*   A) The app makes a request to the auth server asking for an **authorization
-    code** (hence `response_type=code` parameter). This is a short lived code
-    that is sent back to the app if the user authentication is successful. This
-    step may involve some user interactions to establish the identity of the
-    user and pick a patient if the user has access to multiple patients.
-*   B) If the authentication/authorization is successful, the app receives the
-    authorization code AC. The optional parameter `state` is recommended to be
-    used in steps A and B for added security (to prevent replay attacks). In
-    that case, the app and auth server verify the `state`.
-*   C) The app asks for an exchange of AC with an **access token**.
+- A) The app makes a request to the auth server asking for an **authorization
+  code** (hence `response_type=code` parameter). This is a short lived code that
+  is sent back to the app if the user authentication is successful. This step
+  may involve some user interactions to establish the identity of the user and
+  pick a patient if the user has access to multiple patients.
+- B) If the authentication/authorization is successful, the app receives the
+  authorization code AC. The optional parameter `state` is recommended to be
+  used in steps A and B for added security (to prevent replay attacks). In that
+  case, the app and auth server verify the `state`.
+- C) The app asks for an exchange of AC with an **access token**.
 
-*   D) The auth server verifies AC and on success returns an access token AT,
-    along with the approved scopes and other authorization claims needed for
-    access control.
+- D) The auth server verifies AC and on success returns an access token AT,
+  along with the approved scopes and other authorization claims needed for
+  access control.
 
-*   E) The app uses the access token AT to read patient related resources from
-    the FHIR store. At this point, the gateway imposes the access-control
-    restrictions implied by AT.
+- E) The app uses the access token AT to read patient related resources from the
+  FHIR store. At this point, the gateway imposes the access-control restrictions
+  implied by AT.
 
 ### Other architectures
 
@@ -264,8 +259,8 @@ compliant service.
 **Separate IDP**
 
 If desired, the IDP can be separated and a third-party shared service be used.
-In this case, IDP provides an [ID
-token](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1#id-tokens)
+In this case, IDP provides an
+[ID token](https://developer.okta.com/blog/2017/07/25/oidc-primer-part-1#id-tokens)
 to AuthZ which in turn maps the user identity to some access rules to FHIR
 resources. Popular IAM servers like [Keycloak](https://www.keycloak.org/),
 support separate/3rd party IDPs.
@@ -292,15 +287,15 @@ not access information beyond what the user is granted to. This is done by the
 Access Gateway which sits between the app and FHIR store. This is where all ACLs
 are applied; here are some examples we want to eventually support:
 
-*   For a practitioner, only access to their own patients are granted. The
-    definition of one's patients could be configured through implementation of
-    the access-checker plugin. For example:
-    *   Patients in a specific FHIR List resource.
-    *   Any patient in CHW's catchment area.
-    *   Any patient whose `generalPractitioner` contains that CHW.
-*   Observations of sensitive types can only be accessed by certain users.
-*   For a patient user, only access to their own data is granted and SoF scopes
-    rules are imposed too.
+- For a practitioner, only access to their own patients are granted. The
+  definition of one's patients could be configured through implementation of the
+  access-checker plugin. For example:
+  - Patients in a specific FHIR List resource.
+  - Any patient in CHW's catchment area.
+  - Any patient whose `generalPractitioner` contains that CHW.
+- Observations of sensitive types can only be accessed by certain users.
+- For a patient user, only access to their own data is granted and SoF scopes
+  rules are imposed too.
 
 Note we are not assuming any access-control support from the FHIR store itself
 because of the **generalizable-design** [constraint](#scenarios-and-constrants).
@@ -310,13 +305,13 @@ challenges before diving into solutions. Some examples are provided in the
 [query examples appendix](#fhir-query-examples-and-access-control-challenges).
 We propose four main approaches for access control:
 
-*   **Patient context enforcement**: Limit queries to data for a single patient
-*   **Query templates**: Limit the non-patient queries to a small number of
-    templates.
-*   **Query rewrite**: Send a modified query to the FHIR store which guarantees
-    access-control requirements.
-*   **Post processing**: Post process FHIR store results and redact sensitive
-    information.
+- **Patient context enforcement**: Limit queries to data for a single patient
+- **Query templates**: Limit the non-patient queries to a small number of
+  templates.
+- **Query rewrite**: Send a modified query to the FHIR store which guarantees
+  access-control requirements.
+- **Post processing**: Post process FHIR store results and redact sensitive
+  information.
 
 By providing developers the ability to customize each of these, we believe that
 this gateway can support many different models of access control, which often
@@ -331,8 +326,8 @@ first look at the architecture of the gateway. There are two main components:
 **[Server](https://github.com/google/fhir-access-proxy/tree/main/server/src/main/java/com/google/fhir/gateway)**:
 The core of the access gateway is the "server" which provides a
 [servlet](https://github.com/google/fhir-access-proxy/blob/main/server/src/main/java/com/google/fhir/gateway/FhirProxyServer.java)
-that processes FHIR queries and an [authorization
-interceptor](https://github.com/google/fhir-access-proxy/blob/main/server/src/main/java/com/google/fhir/gateway/BearerAuthorizationInterceptor.java)
+that processes FHIR queries and an
+[authorization interceptor](https://github.com/google/fhir-access-proxy/blob/main/server/src/main/java/com/google/fhir/gateway/BearerAuthorizationInterceptor.java)
 that inspects those. The interceptor decodes and validates the JWT access-token
 and makes a call to an
 [AccessChecker](https://github.com/google/fhir-access-proxy/blob/main/server/src/main/java/com/google/fhir/gateway/interfaces/AccessChecker.java)
@@ -342,11 +337,10 @@ provides common FHIR query/resource processing, e.g.,
 for finding patient context. These libraries are meant to be used in the plugin
 implementations.
 
-**[AccessChecker
-plugin](https://github.com/google/fhir-access-proxy/tree/main/plugins)**: Each
-access gateway needs at least one AccessChecker plugin. Gateway implementers can
-provide their customized access-check logic in this plugin. The server code's
-initialization finds plugins by looking for
+**[AccessChecker plugin](https://github.com/google/fhir-access-proxy/tree/main/plugins)**:
+Each access gateway needs at least one AccessChecker plugin. Gateway
+implementers can provide their customized access-check logic in this plugin. The
+server code's initialization finds plugins by looking for
 [AccessCheckerFactory](https://github.com/google/fhir-access-proxy/blob/main/server/src/main/java/com/google/fhir/gateway/interfaces/AccessCheckerFactory.java)
 implementations that are
 [@Named](https://docs.oracle.com/javaee/7/api/javax/inject/Named.html). The
@@ -369,8 +363,8 @@ Most of the use-cases we have can be handled if we limit a query to a single
 patient's resource. For example an Observation search query with a `patient=PID`
 query parameter, guarantees that the result is for the given patient.
 
-The mapping from resources to patients is done through the [patient
-compartment](https://www.hl7.org/fhir/compartmentdefinition-patient.html)
+The mapping from resources to patients is done through the
+[patient compartment](https://www.hl7.org/fhir/compartmentdefinition-patient.html)
 definition. Note that we can still access many resources in one query; in
 particular through
 [Patient/ID/$everything](https://hl7.org/fhir/patient-operation-everything.html)
@@ -379,8 +373,8 @@ queries, we can fetch all updates for a single patient.
 This approach helps support both the **flexible-access-control** and
 **untrusted-app** items from the [constraints](#scenarios-and-constraints)
 section. Note to use this approach for access-control, the patient context
-should be inferred from the FHIR query. The server provides [a
-library](https://github.com/google/fhir-access-proxy/blob/main/server/src/main/java/com/google/fhir/gateway/PatientFinderImp.java)
+should be inferred from the FHIR query. The server provides
+[a library](https://github.com/google/fhir-access-proxy/blob/main/server/src/main/java/com/google/fhir/gateway/PatientFinderImp.java)
 for doing this.
 
 ### Query templates allowed/blocked list
@@ -399,8 +393,8 @@ page pattern. These queries with a `_getpages` query parameter identify cached
 search results of a previous query. Just from these queries, we cannot decide
 what the patient context is, so we should let those queries go through (there is
 a security risk here but since `_getpages` param values are ephemeral UUIDs,
-this is probably ok). Here is a [sample
-config](https://github.com/google/fhir-access-proxy/blob/main/resources/hapi_page_url_allowed_queries.json)
+this is probably ok). Here is a
+[sample config](https://github.com/google/fhir-access-proxy/blob/main/resources/hapi_page_url_allowed_queries.json)
 for this. We note that we want our core "server" to be _stateless_ (for easy
 scalability); therefore cannot store next/prev URLs from previous query results.
 
@@ -420,9 +414,9 @@ then checks if the user has access to those. For example, when fetching a
 resource by ID (e.g., `/Observation/obs-id`) it is impossible to determine the
 patient context from the query string. So we can fetch the resource and then
 check if the user is allowed to access the patient(s) referenced in that
-resource. Or we can apply [security
-label](https://www.hl7.org/fhir/security-labels.html) constraints. Note these
-imply some non-trivial overhead work for processing FHIR resources.
+resource. Or we can apply
+[security label](https://www.hl7.org/fhir/security-labels.html) constraints.
+Note these imply some non-trivial overhead work for processing FHIR resources.
 
 Note that even this kind of fine-grained control, does not address all of the
 sensitive-data scenarios because of reverse chaining (if we do not limit the
@@ -443,36 +437,35 @@ server.
 Here is a demonstration of how a sample HCW app can fetch data from a FHIR
 server while access-control policies apply.
 
-*   The client app redirects the HCW to the "auth server" (AuthZ+IDP) to
-    authenticate the user and annotate their access tokens with required
-    authorization claims.
-*   The client fetches the access token from AuthZ.
-*   The client sends the access token along with a FHIR query to the access
-    gateway.
-*   The gateway verifies the token and checks that every resource accessed
-    belongs to a patient the client is authorized to access and/or is compatible
-    with the authorized templates.
-*   The gateway relays the query to the FHIR store.
-*   Upon the store's response, the gateway makes any post-processing required
-    and returns the outcome to the client.
+- The client app redirects the HCW to the "auth server" (AuthZ+IDP) to
+  authenticate the user and annotate their access tokens with required
+  authorization claims.
+- The client fetches the access token from AuthZ.
+- The client sends the access token along with a FHIR query to the access
+  gateway.
+- The gateway verifies the token and checks that every resource accessed belongs
+  to a patient the client is authorized to access and/or is compatible with the
+  authorized templates.
+- The gateway relays the query to the FHIR store.
+- Upon the store's response, the gateway makes any post-processing required and
+  returns the outcome to the client.
 
 Through this process, **add-patient**, **update-patient**, and
 **fetch-my-patients** [scenarios](#scenarios-and-constraints) can be handled. To
 support **sof-apps** (assuming that the auth server supports SoF scopes), we
 should implement access control rules based on SoF scopes (which is provided in
-a plugin). One example of an auth server with SoF support is [Keycloak with SoF
-extension](https://github.com/Alvearie/keycloak-extensions-for-fhir).
+a plugin). One example of an auth server with SoF support is
+[Keycloak with SoF extension](https://github.com/Alvearie/keycloak-extensions-for-fhir).
 
 ## Relevant documents and background information
 
-*   [FHIR Security page](https://www.hl7.org/fhir/security.html).
-*   A [collection of resources](https://docs.smarthealthit.org/) about SMART on
-    FHIR from SMART Health.
-*   An [extension to
-    Keycloak](https://github.com/Alvearie/keycloak-extensions-for-fhir) to
-    support SMART on FHIR claims.
-*   [New version of SMART scopes and context
-    document](http://build.fhir.org/ig/HL7/smart-app-launch/scopes-and-launch-context.html).
+- [FHIR Security page](https://www.hl7.org/fhir/security.html).
+- A [collection of resources](https://docs.smarthealthit.org/) about SMART on
+  FHIR from SMART Health.
+- An
+  [extension to Keycloak](https://github.com/Alvearie/keycloak-extensions-for-fhir)
+  to support SMART on FHIR claims.
+- [New version of SMART scopes and context document](http://build.fhir.org/ig/HL7/smart-app-launch/scopes-and-launch-context.html).
 
 ## Appendix
 
@@ -487,9 +480,9 @@ constraints are that a HCW should not have access to:
 
 The three queries are:
 
-*   fetching all Patients
-*   accessing sensitive Observations
-*   reverse chaining searches
+- fetching all Patients
+- accessing sensitive Observations
+- reverse chaining searches
 
 For each query, we look at possible ways we can implement access control rules.
 
@@ -500,41 +493,40 @@ if the query is
 
 "`GET [base]/Patient`"? Some options are:
 
-*   [**permitted-templates**] We can reject the query because it is not in the
-    list of permitted query templates; the relevant permitted template could
-    have a parameter that limits the patient, practitioner, location, etc. (see
-    below).
-*   [**query-rewrite**] We can add a constraint to impose a location based
-    restriction, e.g., if the current CHW user has access to patients in city
-    "CityHCW":
+- [**permitted-templates**] We can reject the query because it is not in the
+  list of permitted query templates; the relevant permitted template could have
+  a parameter that limits the patient, practitioner, location, etc. (see below).
+- [**query-rewrite**] We can add a constraint to impose a location based
+  restriction, e.g., if the current CHW user has access to patients in city
+  "CityHCW":
 
-    ```
-    GET [base]/Patient?address-city=CityCHW
-    ```
+  ```
+  GET [base]/Patient?address-city=CityCHW
+  ```
 
-*   [**query-rewrite**] We can add a practitioner constraint e,g.,:
+- [**query-rewrite**] We can add a practitioner constraint e,g.,:
 
-    ```
-    GET [base]/Patient?general-practitioner=Practitioner/HCW-ID
-    ```
+  ```
+  GET [base]/Patient?general-practitioner=Practitioner/HCW-ID
+  ```
 
-*   [**post-processing**] We can retrieve all results from the FHIR store, then
-    post-process them and drop everything that does not belong to this HCW.
+- [**post-processing**] We can retrieve all results from the FHIR store, then
+  post-process them and drop everything that does not belong to this HCW.
 
 #### Sensitive data
 
 Now let's consider access to _sensitive data_. Assume that the HIV status is a
 sensitive Observation that we don't want to expose to some HCWs. What should we
-do for the following query that fetches all Observations of a patient: "`GET
-/Observation?subject=Patient/PID`"?
+do for the following query that fetches all Observations of a patient:
+"`GET /Observation?subject=Patient/PID`"?
 
-*   [**query-rewrite**] Add the constraint to drop viral load for HIV:
+- [**query-rewrite**] Add the constraint to drop viral load for HIV:
 
-    "`GET /Observation?subject=Patient/PID&code:not=http://loinc.org|59419-2`"
+  "`GET /Observation?subject=Patient/PID&code:not=http://loinc.org|59419-2`"
 
-*   [**permitted-templates**] Similar to the above "all patients" example.
-*   [**post-processing**] From the returned results, remove all Observation
-    resources that have HIV viral load code.
+- [**permitted-templates**] Similar to the above "all patients" example.
+- [**post-processing**] From the returned results, remove all Observation
+  resources that have HIV viral load code.
 
 Note for the first two options we should probably use a
 [ValueSet](https://hl7.org/fhir/valueset.html) if there are a lot of Observation
@@ -545,8 +537,7 @@ codes that we want to protect.
 Finally, to see how this problem can get complicated quickly, consider this
 query:
 
-"`GET
-[base]/Patient?_id=PID&_has:Observation:patient:code-value-quantity=http://loinc.org|59419-2$gt1000||`".
+"`GET [base]/Patient?_id=PID&_has:Observation:patient:code-value-quantity=http://loinc.org|59419-2$gt1000||`".
 
 This query is a _[reverse chaining](https://www.hl7.org/fhir/search.html#has)_
 query which returns the queried Patients if they had a high HIV viral load.
@@ -561,4 +552,11 @@ In the main text, we refer to these examples by "all-patients",
 
 ## Notes
 
-[^1]: The simplified [Implicit](https://smilecdr.com/docs/smart/smart_on_fhir_authorization_flows.html#launch-flow-implicit-grant) flow could work for our use-case too but that has important security shortcomings. For example, it exposes access_token in URLs which can leak through browser history. Another more important shortcoming is that we cannot implement PKCE in the Implicit flow as the access_token is directly returned in the first request.
+[^1]:
+    The simplified
+    [Implicit](https://smilecdr.com/docs/smart/smart_on_fhir_authorization_flows.html#launch-flow-implicit-grant)
+    flow could work for our use-case too but that has important security
+    shortcomings. For example, it exposes access_token in URLs which can leak
+    through browser history. Another more important shortcoming is that we
+    cannot implement PKCE in the Implicit flow as the access_token is directly
+    returned in the first request.

--- a/exec/pom.xml
+++ b/exec/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.fhir.gateway</groupId>
     <artifactId>fhir-gateway</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
   </parent>
 
   <artifactId>exec</artifactId>
@@ -30,6 +30,8 @@
   <properties>
     <root.basedir>${project.parent.basedir}</root.basedir>
     <spring-boot.version>2.7.5</spring-boot.version>
+    <!-- We do not want to deploy the `exec` uber jar. -->
+    <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
 
   <dependencyManagement>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -23,7 +23,7 @@
     implementations do not have to do this; they can redeclare those deps. -->
     <groupId>com.google.fhir.gateway</groupId>
     <artifactId>fhir-gateway</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
   </parent>
 
   <artifactId>plugins</artifactId>

--- a/plugins/src/main/java/com/google/fhir/gateway/plugin/PatientAccessChecker.java
+++ b/plugins/src/main/java/com/google/fhir/gateway/plugin/PatientAccessChecker.java
@@ -154,7 +154,9 @@ public class PatientAccessChecker implements AccessChecker {
   private AccessDecision processBundle(RequestDetailsReader requestDetails) {
     BundlePatients patientsInBundle = patientFinder.findPatientsInBundle(requestDetails);
 
-    if (patientsInBundle == null || patientsInBundle.areTherePatientToCreate()) {
+    if (patientsInBundle == null
+        || patientsInBundle.areTherePatientToCreate()
+        || !patientsInBundle.getDeletedPatients().isEmpty()) {
       return NoOpAccessDecision.accessDenied();
     }
 

--- a/plugins/src/main/java/com/google/fhir/gateway/plugin/PatientAccessChecker.java
+++ b/plugins/src/main/java/com/google/fhir/gateway/plugin/PatientAccessChecker.java
@@ -16,6 +16,7 @@
 package com.google.fhir.gateway.plugin;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.api.RequestTypeEnum;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.google.common.annotations.VisibleForTesting;
@@ -32,16 +33,31 @@ import com.google.fhir.gateway.interfaces.AccessDecision;
 import com.google.fhir.gateway.interfaces.NoOpAccessDecision;
 import com.google.fhir.gateway.interfaces.PatientFinder;
 import com.google.fhir.gateway.interfaces.RequestDetailsReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.inject.Named;
-import org.hl7.fhir.r4.model.Bundle.HTTPVerb;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryRequestComponent;
+import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This access-checker uses the `patient_id` claim in the access token to decide whether access to a
- * request should be granted or not.
+ * This access-checker uses the `patient_id` and the `scope` claim in the access token to decide
+ * whether access to a request should be granted or not. The `scope` claims are expected to tbe
+ * SMART-on-FHIR compliant.
  */
 public class PatientAccessChecker implements AccessChecker {
   private static final Logger logger = LoggerFactory.getLogger(PatientAccessChecker.class);
@@ -49,16 +65,33 @@ public class PatientAccessChecker implements AccessChecker {
   private final String authorizedPatientId;
   private final PatientFinder patientFinder;
 
-  private PatientAccessChecker(String authorizedPatientId, PatientFinder patientFinder) {
+  private final FhirContext fhirContext;
+  private final Map<String, Set<SmartFhirScopeResourcePermission>> permissionsByResourceType;
+
+  private PatientAccessChecker(
+      FhirContext fhirContext,
+      String authorizedPatientId,
+      PatientFinder patientFinder,
+      List<SmartFhirScope> scopes) {
     Preconditions.checkNotNull(authorizedPatientId);
     Preconditions.checkNotNull(patientFinder);
+    Preconditions.checkNotNull(scopes);
+    Preconditions.checkNotNull(fhirContext);
     this.authorizedPatientId = authorizedPatientId;
     this.patientFinder = patientFinder;
+    this.fhirContext = fhirContext;
+    this.permissionsByResourceType =
+        scopes.stream()
+            .collect(
+                Collectors.groupingBy(
+                    SmartFhirScope::getResourceType,
+                    Collectors.flatMapping(
+                        resourceScopes -> resourceScopes.getResourcePermissions().stream(),
+                        Collectors.toSet())));
   }
 
   @Override
   public AccessDecision checkAccess(RequestDetailsReader requestDetails) {
-
     // For a Bundle requestDetails.getResourceName() returns null
     if (requestDetails.getRequestType() == RequestTypeEnum.POST
         && requestDetails.getResourceName() == null) {
@@ -71,9 +104,10 @@ public class PatientAccessChecker implements AccessChecker {
       case POST:
         return processPost(requestDetails);
       case PUT:
-        return processPut(requestDetails);
+        // TODO(https://github.com/google/fhir-gateway/issues/88): Support update as create
+        // operation
       case PATCH:
-        return processPatch(requestDetails);
+        return processUpdate(requestDetails);
       case DELETE:
         return processDelete(requestDetails);
       default:
@@ -82,31 +116,63 @@ public class PatientAccessChecker implements AccessChecker {
   }
 
   private AccessDecision processGet(RequestDetailsReader requestDetails) {
-    String patientId = patientFinder.findPatientFromParams(requestDetails);
-    return new NoOpAccessDecision(authorizedPatientId.equals(patientId));
+    if (requestDetails.getResourceName() == null) {
+      return NoOpAccessDecision.accessDenied();
+    }
+    // This operation corresponds to the read/vread/history operations on instance
+    if (requestDetails.getId() != null) {
+      return processRead(requestDetails);
+    }
+    return processSearch(requestDetails);
   }
 
   private AccessDecision processPost(RequestDetailsReader requestDetails) {
+    // TODO(https://github.com/google/fhir-gateway/issues/87): Add support for search in post
+    return processCreate(requestDetails);
+  }
+
+  private boolean hasPermission(String resourceType, SmartFhirScopeResourcePermission permission) {
+    return this.permissionsByResourceType
+            .getOrDefault(resourceType, Collections.emptySet())
+            .contains(permission)
+        || this.permissionsByResourceType
+            .getOrDefault(SmartFhirScope.ALL_RESOURCE_TYPES_WILDCARD, Collections.emptySet())
+            .contains(permission);
+  }
+
+  private AccessDecision processRead(RequestDetailsReader requestDetails) {
+    String patientId = patientFinder.findPatientFromParams(requestDetails);
+    return new NoOpAccessDecision(
+        authorizedPatientId.equals(patientId)
+            && hasPermission(
+                requestDetails.getResourceName(), SmartFhirScopeResourcePermission.READ));
+  }
+
+  private AccessDecision processSearch(RequestDetailsReader requestDetails) {
+    String patientId = patientFinder.findPatientFromParams(requestDetails);
+    return new NoOpAccessDecision(
+        authorizedPatientId.equals(patientId)
+            && hasPermission(
+                requestDetails.getResourceName(), SmartFhirScopeResourcePermission.SEARCH));
+  }
+
+  private AccessDecision processCreate(RequestDetailsReader requestDetails) {
     // This AccessChecker does not accept new patients.
     if (FhirUtil.isSameResourceType(requestDetails.getResourceName(), ResourceType.Patient)) {
       return NoOpAccessDecision.accessDenied();
     }
     Set<String> patientIds = patientFinder.findPatientsInResource(requestDetails);
-    return new NoOpAccessDecision(patientIds.contains(authorizedPatientId));
+    return new NoOpAccessDecision(
+        patientIds.contains(authorizedPatientId)
+            && hasPermission(
+                requestDetails.getResourceName(), SmartFhirScopeResourcePermission.CREATE));
   }
 
-  private AccessDecision processPut(RequestDetailsReader requestDetails) {
+  private AccessDecision processUpdate(RequestDetailsReader requestDetails) {
     if (FhirUtil.isSameResourceType(requestDetails.getResourceName(), ResourceType.Patient)) {
       return checkPatientAccessInUpdate(requestDetails);
     }
-    return checkNonPatientAccessInUpdate(requestDetails, HTTPVerb.PUT);
-  }
-
-  private AccessDecision processPatch(RequestDetailsReader requestDetails) {
-    if (FhirUtil.isSameResourceType(requestDetails.getResourceName(), ResourceType.Patient)) {
-      return checkPatientAccessInUpdate(requestDetails);
-    }
-    return checkNonPatientAccessInUpdate(requestDetails, HTTPVerb.PATCH);
+    return checkNonPatientAccessInUpdate(requestDetails, requestDetails.getRequestType());
   }
 
   private AccessDecision processDelete(RequestDetailsReader requestDetails) {
@@ -116,11 +182,14 @@ public class PatientAccessChecker implements AccessChecker {
     }
     // TODO(https://github.com/google/fhir-access-proxy/issues/63):Support direct resource deletion.
     String patientId = patientFinder.findPatientFromParams(requestDetails);
-    return new NoOpAccessDecision(authorizedPatientId.equals(patientId));
+    return new NoOpAccessDecision(
+        authorizedPatientId.equals(patientId)
+            && hasPermission(
+                requestDetails.getResourceName(), SmartFhirScopeResourcePermission.DELETE));
   }
 
   private AccessDecision checkNonPatientAccessInUpdate(
-      RequestDetailsReader requestDetails, HTTPVerb updateMethod) {
+      RequestDetailsReader requestDetails, RequestTypeEnum updateMethod) {
     // We do not allow direct resource PUT/PATCH, so Patient ID must be returned
     String patientId = patientFinder.findPatientFromParams(requestDetails);
     if (!patientId.equals(authorizedPatientId)) {
@@ -128,17 +197,20 @@ public class PatientAccessChecker implements AccessChecker {
     }
 
     Set<String> patientIds = Sets.newHashSet();
-    if (updateMethod == HTTPVerb.PATCH) {
+    if (updateMethod == RequestTypeEnum.PATCH) {
       patientIds =
           patientFinder.findPatientsInPatch(requestDetails, requestDetails.getResourceName());
       if (patientIds.isEmpty()) {
         return NoOpAccessDecision.accessGranted();
       }
     }
-    if (updateMethod == HTTPVerb.PUT) {
+    if (updateMethod == RequestTypeEnum.PUT) {
       patientIds = patientFinder.findPatientsInResource(requestDetails);
     }
-    return new NoOpAccessDecision(patientIds.contains(authorizedPatientId));
+    return new NoOpAccessDecision(
+        patientIds.contains(authorizedPatientId)
+            && hasPermission(
+                requestDetails.getResourceName(), SmartFhirScopeResourcePermission.UPDATE));
   }
 
   private AccessDecision checkPatientAccessInUpdate(RequestDetailsReader requestDetails) {
@@ -148,7 +220,9 @@ public class PatientAccessChecker implements AccessChecker {
       logger.error("The provided Patient resource has no ID; denying access!");
       return NoOpAccessDecision.accessDenied();
     }
-    return new NoOpAccessDecision(authorizedPatientId.equals(patientId));
+    return new NoOpAccessDecision(
+        authorizedPatientId.equals(patientId)
+            && hasPermission(ResourceType.Patient.name(), SmartFhirScopeResourcePermission.UPDATE));
   }
 
   private AccessDecision processBundle(RequestDetailsReader requestDetails) {
@@ -170,7 +244,86 @@ public class PatientAccessChecker implements AccessChecker {
         return NoOpAccessDecision.accessDenied();
       }
     }
+
+    Bundle requestBundle = createBundleFromRequest(requestDetails);
+    if (requestBundle == null) {
+      return NoOpAccessDecision.accessDenied();
+    }
+    for (BundleEntryComponent entryComponent : requestBundle.getEntry()) {
+      if (!doesBundleElementHavePermission(entryComponent)) {
+        return NoOpAccessDecision.accessDenied();
+      }
+    }
     return NoOpAccessDecision.accessGranted();
+  }
+
+  private Bundle createBundleFromRequest(RequestDetailsReader request) {
+    byte[] requestContentBytes = request.loadRequestContents();
+    Charset charset = request.getCharset();
+    if (charset == null) {
+      charset = StandardCharsets.UTF_8;
+    }
+    String requestContent = new String(requestContentBytes, charset);
+    IParser jsonParser = fhirContext.newJsonParser();
+    IBaseResource resource = jsonParser.parseResource(requestContent);
+    if (!(resource instanceof Bundle)) {
+      return null;
+    }
+    return (Bundle) resource;
+  }
+
+  private boolean doesReferenceElementHavePermission(
+      IIdType referenceElement, SmartFhirScopeResourcePermission permission) {
+    if (referenceElement.getResourceType() != null && referenceElement.hasIdPart()) {
+      return hasPermission(referenceElement.getResourceType(), permission);
+    } else {
+      return hasPermission(referenceElement.getValue(), permission);
+    }
+  }
+
+  private boolean doesBundleElementHavePermission(BundleEntryComponent bundleEntry) {
+    BundleEntryRequestComponent bundleEntryRequest = bundleEntry.getRequest();
+    try {
+      switch (bundleEntryRequest.getMethod()) {
+        case GET:
+          if (bundleEntryRequest.getUrl() != null) {
+            URI resourceUri = new URI(bundleEntryRequest.getUrl());
+            IIdType referenceElement = new Reference(resourceUri.getPath()).getReferenceElement();
+            return doesReferenceElementHavePermission(
+                referenceElement, SmartFhirScopeResourcePermission.READ);
+          }
+          break;
+        case POST:
+          if (bundleEntry.getResource().getResourceType() != null) {
+            return hasPermission(
+                bundleEntry.getResource().getResourceType().name(),
+                SmartFhirScopeResourcePermission.CREATE);
+          }
+          // TODO(https://github.com/google/fhir-gateway/issues/87): Add support for search in post
+          break;
+        case PUT:
+          if (bundleEntryRequest.getUrl() != null) {
+            URI resourceUri = new URI(bundleEntryRequest.getUrl());
+            IIdType referenceElement = new Reference(resourceUri.getPath()).getReferenceElement();
+            return doesReferenceElementHavePermission(
+                referenceElement, SmartFhirScopeResourcePermission.UPDATE);
+          }
+          break;
+        case PATCH:
+          if (bundleEntryRequest.getUrl() != null) {
+            URI resourceUri = new URI(bundleEntryRequest.getUrl());
+            IIdType referenceElement = new Reference(resourceUri.getPath()).getReferenceElement();
+            return doesReferenceElementHavePermission(
+                referenceElement, SmartFhirScopeResourcePermission.UPDATE);
+          }
+        default:
+          return false;
+      }
+    } catch (URISyntaxException e) {
+      logger.error(
+          String.format("Error in parsing bundle request url %s", bundleEntryRequest.getUrl()));
+    }
+    return false;
   }
 
   @Named(value = "patient")
@@ -178,8 +331,20 @@ public class PatientAccessChecker implements AccessChecker {
 
     @VisibleForTesting static final String PATIENT_CLAIM = "patient_id";
 
+    @VisibleForTesting static final String SCOPES_CLAIM = "scope";
+
     private String getPatientId(DecodedJWT jwt) {
       return FhirUtil.checkIdOrFail(JwtUtil.getClaimOrDie(jwt, PATIENT_CLAIM));
+    }
+
+    private List<SmartFhirScope> getPatientScopes(DecodedJWT jwt) {
+      String scopesClaim = JwtUtil.getClaimOrDie(jwt, SCOPES_CLAIM);
+      String[] scopes = scopesClaim.strip().split("\\s+");
+      return SmartFhirScope.extractSmartFhirScopesFromTokens(Arrays.asList(scopes)).stream()
+          .filter(
+              smartFhirScope ->
+                  smartFhirScope.principalContext == SmartFhirScopeResourcePrincipalContext.PATIENT)
+          .collect(Collectors.toList());
     }
 
     public AccessChecker create(
@@ -187,7 +352,8 @@ public class PatientAccessChecker implements AccessChecker {
         HttpFhirClient httpFhirClient,
         FhirContext fhirContext,
         PatientFinder patientFinder) {
-      return new PatientAccessChecker(getPatientId(jwt), patientFinder);
+      return new PatientAccessChecker(
+          fhirContext, getPatientId(jwt), patientFinder, getPatientScopes(jwt));
     }
   }
 }

--- a/plugins/src/main/java/com/google/fhir/gateway/plugin/PatientAccessChecker.java
+++ b/plugins/src/main/java/com/google/fhir/gateway/plugin/PatientAccessChecker.java
@@ -127,8 +127,7 @@ public class PatientAccessChecker implements AccessChecker {
     String patientId = patientFinder.findPatientFromParams(requestDetails);
     return new NoOpAccessDecision(
         authorizedPatientId.equals(patientId)
-            && smartScopeChecker.hasPermission(
-                requestDetails.getResourceName(), Permission.READ));
+            && smartScopeChecker.hasPermission(requestDetails.getResourceName(), Permission.READ));
   }
 
   private AccessDecision processSearch(RequestDetailsReader requestDetails) {
@@ -205,8 +204,7 @@ public class PatientAccessChecker implements AccessChecker {
     }
     return new NoOpAccessDecision(
         authorizedPatientId.equals(patientId)
-            && smartScopeChecker.hasPermission(
-                ResourceType.Patient.name(), Permission.UPDATE));
+            && smartScopeChecker.hasPermission(ResourceType.Patient.name(), Permission.UPDATE));
   }
 
   private AccessDecision processBundle(RequestDetailsReader requestDetails) {
@@ -261,8 +259,7 @@ public class PatientAccessChecker implements AccessChecker {
   private boolean doesReferenceElementHavePermission(
       IIdType referenceElement, Permission permission) {
     if (referenceElement.getResourceType() != null && referenceElement.hasIdPart()) {
-      return smartScopeChecker.hasPermission(
-          referenceElement.getResourceType(), permission);
+      return smartScopeChecker.hasPermission(referenceElement.getResourceType(), permission);
     } else {
       return smartScopeChecker.hasPermission(referenceElement.getValue(), permission);
     }

--- a/plugins/src/main/java/com/google/fhir/gateway/plugin/SmartFhirPermissionChecker.java
+++ b/plugins/src/main/java/com/google/fhir/gateway/plugin/SmartFhirPermissionChecker.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.fhir.gateway.plugin;
+
+import com.google.fhir.gateway.plugin.SmartFhirScope.Permission;
+import com.google.fhir.gateway.plugin.SmartFhirScope.PrincipalContext;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class SmartFhirPermissionChecker {
+
+  private final Map<String, Set<SmartFhirScope.Permission>> permissionsByResourceType;
+
+  SmartFhirPermissionChecker(List<SmartFhirScope> scopes, PrincipalContext permissionContext) {
+    this.permissionsByResourceType =
+        scopes.stream()
+            .filter(smartFhirScope -> smartFhirScope.getPrincipalContext() == permissionContext)
+            .collect(
+                Collectors.groupingBy(
+                    SmartFhirScope::getResourceType,
+                    Collectors.flatMapping(
+                        resourceScopes -> resourceScopes.getPermissions().stream(),
+                        Collectors.toSet())));
+  }
+
+  boolean hasPermission(String resourceType, Permission permission) {
+    return this.permissionsByResourceType
+            .getOrDefault(resourceType, Collections.emptySet())
+            .contains(permission)
+        || this.permissionsByResourceType
+            .getOrDefault(SmartFhirScope.ALL_RESOURCE_TYPES_WILDCARD, Collections.emptySet())
+            .contains(permission);
+  }
+}

--- a/plugins/src/main/java/com/google/fhir/gateway/plugin/SmartFhirScope.java
+++ b/plugins/src/main/java/com/google/fhir/gateway/plugin/SmartFhirScope.java
@@ -130,10 +130,11 @@ public class SmartFhirScope {
   }
 
   /**
-   * SMART Permission to specify the kind of permission that is allowed on a Resource.
-   * The order of the Permission is important to us in the way it has been listed here.
-   * Please see: https://build.fhir.org/ig/HL7/smart-app-launch/scopes-and-launch-context.html#scopes-for-requesting-clinical-data
-   * The given order of Permissions is how it is expected that permissions will be specified in the token claim
+   * SMART Permission to specify the kind of permission that is allowed on a Resource. The order of
+   * the Permission is important to us in the way it has been listed here. Please see:
+   * https://build.fhir.org/ig/HL7/smart-app-launch/scopes-and-launch-context.html#scopes-for-requesting-clinical-data
+   * The given order of Permissions is how it is expected that permissions will be specified in the
+   * token claim
    */
   enum Permission {
     CREATE,

--- a/plugins/src/main/java/com/google/fhir/gateway/plugin/SmartFhirScope.java
+++ b/plugins/src/main/java/com/google/fhir/gateway/plugin/SmartFhirScope.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2021-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.fhir.gateway.plugin;
+
+import com.google.fhir.gateway.FhirUtil;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+public class SmartFhirScope {
+  SmartFhirScopeResourcePrincipalContext principalContext;
+  String resourceType;
+
+  public SmartFhirScopeResourcePrincipalContext getPrincipalContext() {
+    return principalContext;
+  }
+
+  public String getResourceType() {
+    return resourceType;
+  }
+
+  public Set<SmartFhirScopeResourcePermission> getResourcePermissions() {
+    return resourcePermissions;
+  }
+
+  Set<SmartFhirScopeResourcePermission> resourcePermissions;
+
+  private SmartFhirScope(
+      SmartFhirScopeResourcePrincipalContext principalContext,
+      String resourceType,
+      Set<SmartFhirScopeResourcePermission> resourcePermissions) {
+    this.principalContext = principalContext;
+    this.resourcePermissions = resourcePermissions;
+    this.resourceType = resourceType;
+  }
+
+  private static final Pattern PATIENT_SCOPE_PATTERN =
+      Pattern.compile(
+          "(\\buser|patient|system\\b)(\\/((\\*)|([a-zA-Z]+)))(\\.((\\*)|([cruds]+)|(\\bread|write\\b)))");
+  static final String ALL_RESOURCE_TYPES_WILDCARD = "*";
+  static final String ALL_RESOURCE_PERMISSIONS_WILDCARD = "*";
+  static final String SMART_V1_READ_RESOURCE_PERMISSIONS = "read";
+  static final String SMART_V1_WRITE_RESOURCE_PERMISSIONS = "write";
+
+  private static final List<SmartFhirScopeResourcePermission> resourcePermissionsSequence =
+      List.of(
+          SmartFhirScopeResourcePermission.CREATE,
+          SmartFhirScopeResourcePermission.READ,
+          SmartFhirScopeResourcePermission.UPDATE,
+          SmartFhirScopeResourcePermission.DELETE,
+          SmartFhirScopeResourcePermission.SEARCH);
+
+  static List<SmartFhirScope> extractSmartFhirScopesFromTokens(List<String> tokens) {
+    List<SmartFhirScope> scopes = new ArrayList<>();
+    for (String scope : tokens) {
+      if (PATIENT_SCOPE_PATTERN.matcher(scope).matches()) {
+        scopes.add(createSmartScope(scope));
+      }
+    }
+    return scopes;
+  }
+
+  private static SmartFhirScope createSmartScope(String scope) {
+    String[] principalTokenSplit = scope.split("/");
+    SmartFhirScopeResourcePrincipalContext principalContext =
+        SmartFhirScopeResourcePrincipalContext.getPrincipalContext(principalTokenSplit[0]);
+    String[] resourceTypeAndPermissionSplit = principalTokenSplit[1].split("\\.");
+    if (!isValidResourceType(resourceTypeAndPermissionSplit[0])) {
+      throw new IllegalArgumentException(
+          String.format("Invalid resource type %s", resourceTypeAndPermissionSplit[0]));
+    }
+    String resourceType = resourceTypeAndPermissionSplit[0];
+    Set<SmartFhirScopeResourcePermission> permissions =
+        extractPermissions(resourceTypeAndPermissionSplit[1]);
+    return new SmartFhirScope(principalContext, resourceType, permissions);
+  }
+
+  private static boolean isValidResourceType(String resourceType) {
+    return ALL_RESOURCE_TYPES_WILDCARD.equals(resourceType)
+        || FhirUtil.isValidFhirResourceType(resourceType);
+  }
+
+  private static Set<SmartFhirScopeResourcePermission> extractPermissions(String permissionString) {
+    // TODO(anchitag): Assumes that the permissions are in v2 format only
+    Set<SmartFhirScopeResourcePermission> permissions = new HashSet<>();
+    if (ALL_RESOURCE_PERMISSIONS_WILDCARD.equals(permissionString)) {
+      permissions.addAll(resourcePermissionsSequence);
+      return permissions;
+    }
+    // https://build.fhir.org/ig/HL7/smart-app-launch/scopes-and-launch-context.html#scopes-for-requesting-clinical-data
+    if (SMART_V1_READ_RESOURCE_PERMISSIONS.equals(permissionString)) {
+      permissions.add(SmartFhirScopeResourcePermission.READ);
+      permissions.add(SmartFhirScopeResourcePermission.SEARCH);
+      return permissions;
+    }
+    if (SMART_V1_WRITE_RESOURCE_PERMISSIONS.equals(permissionString)) {
+      permissions.add(SmartFhirScopeResourcePermission.CREATE);
+      permissions.add(SmartFhirScopeResourcePermission.UPDATE);
+      permissions.add(SmartFhirScopeResourcePermission.DELETE);
+      return permissions;
+    }
+    char[] permissionTokens = permissionString.toCharArray();
+    int permissionTokensCounter = 0;
+    for (SmartFhirScopeResourcePermission permission : resourcePermissionsSequence) {
+      if (SmartFhirScopeResourcePermission.getPermission(permissionTokens[permissionTokensCounter])
+          == permission) {
+        permissionTokensCounter++;
+        permissions.add(permission);
+      }
+      if (permissionTokensCounter == permissionTokens.length) {
+        break;
+      }
+    }
+    if (permissionTokensCounter != permissionTokens.length) {
+      throw new IllegalArgumentException(
+          String.format("Invalid permission string %s", permissionString));
+    }
+    return permissions;
+  }
+}
+
+enum SmartFhirScopeResourcePrincipalContext {
+  USER,
+  PATIENT,
+  SYSTEM;
+
+  static SmartFhirScopeResourcePrincipalContext getPrincipalContext(String principal) {
+    switch (principal.toLowerCase()) {
+      case "user":
+        return USER;
+      case "patient":
+        return PATIENT;
+      case "system":
+        return SYSTEM;
+      default:
+        throw new IllegalArgumentException(String.format("Invalid principal %s", principal));
+    }
+  }
+}
+
+enum SmartFhirScopeResourcePermission {
+  CREATE,
+  READ,
+  UPDATE,
+  DELETE,
+  SEARCH;
+
+  static SmartFhirScopeResourcePermission getPermission(char permissionCode) {
+    switch (permissionCode) {
+      case 'c':
+        return CREATE;
+      case 'r':
+        return READ;
+      case 'u':
+        return UPDATE;
+      case 'd':
+        return DELETE;
+      case 's':
+        return SEARCH;
+      default:
+        throw new IllegalArgumentException(
+            String.format("Invalid permission code. %s", permissionCode));
+    }
+  }
+}

--- a/plugins/src/main/java/com/google/fhir/gateway/plugin/SmartScopeChecker.java
+++ b/plugins/src/main/java/com/google/fhir/gateway/plugin/SmartScopeChecker.java
@@ -16,21 +16,21 @@
 package com.google.fhir.gateway.plugin;
 
 import com.google.fhir.gateway.plugin.SmartFhirScope.Permission;
-import com.google.fhir.gateway.plugin.SmartFhirScope.PrincipalContext;
+import com.google.fhir.gateway.plugin.SmartFhirScope.Principal;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class SmartFhirPermissionChecker {
+public class SmartScopeChecker {
 
   private final Map<String, Set<SmartFhirScope.Permission>> permissionsByResourceType;
 
-  SmartFhirPermissionChecker(List<SmartFhirScope> scopes, PrincipalContext permissionContext) {
+  SmartScopeChecker(List<SmartFhirScope> scopes, Principal permissionContext) {
     this.permissionsByResourceType =
         scopes.stream()
-            .filter(smartFhirScope -> smartFhirScope.getPrincipalContext() == permissionContext)
+            .filter(smartFhirScope -> smartFhirScope.getPrincipal() == permissionContext)
             .collect(
                 Collectors.groupingBy(
                     SmartFhirScope::getResourceType,

--- a/plugins/src/test/java/com/google/fhir/gateway/plugin/AccessCheckerTestBase.java
+++ b/plugins/src/test/java/com/google/fhir/gateway/plugin/AccessCheckerTestBase.java
@@ -292,12 +292,22 @@ public abstract class AccessCheckerTestBase {
     testInstance.checkAccess(requestMock).canAccess();
   }
 
-  @Test(expected = InvalidRequestException.class)
-  public void canAccessBundleDeletePatient() throws IOException {
+  @Test
+  public void canAccessBundleDeleteNonPatient() throws IOException {
     // Query: POST / -d @bundle_transaction_delete.json
-    setUpFhirBundle("bundle_transaction_delete.json");
+    setUpFhirBundle("bundle_transaction_delete_non_patient.json");
     AccessChecker testInstance = getInstance();
-    testInstance.checkAccess(requestMock).canAccess();
+
+    assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(true));
+  }
+
+  @Test
+  public void canAccessBundleDeletePatientUnAuthorized() throws IOException {
+    // Query: POST / -d @bundle_transaction_delete_patient_unauthorized.json
+    setUpFhirBundle("bundle_transaction_delete_patient_unauthorized.json");
+    AccessChecker testInstance = getInstance();
+
+    assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(false));
   }
 
   @Test(expected = InvalidRequestException.class)

--- a/plugins/src/test/java/com/google/fhir/gateway/plugin/AccessCheckerTestBase.java
+++ b/plugins/src/test/java/com/google/fhir/gateway/plugin/AccessCheckerTestBase.java
@@ -75,6 +75,7 @@ public abstract class AccessCheckerTestBase {
   public void canAccessTest() {
     // Query: GET /Patient/PATIENT_AUTHORIZED_ID
     when(requestMock.getResourceName()).thenReturn("Patient");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
     when(requestMock.getId()).thenReturn(PATIENT_AUTHORIZED_ID);
     AccessChecker testInstance = getInstance();
     assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(true));
@@ -84,6 +85,7 @@ public abstract class AccessCheckerTestBase {
   public void canAccessNotAuthorized() {
     // Query: GET /Patient/PATIENT_NON_AUTHORIZED_ID
     when(requestMock.getResourceName()).thenReturn("Patient");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
     when(requestMock.getId()).thenReturn(PATIENT_NON_AUTHORIZED_ID);
     AccessChecker testInstance = getInstance();
     assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(false));
@@ -93,6 +95,7 @@ public abstract class AccessCheckerTestBase {
   public void canAccessDirectResourceNotAuthorized() {
     // Query: GET /Observation/a-random-id
     when(requestMock.getResourceName()).thenReturn("Observation");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
     when(requestMock.getId()).thenReturn(new IdDt("a-random-id"));
     AccessChecker testInstance = getInstance();
     testInstance.checkAccess(requestMock).canAccess();
@@ -102,6 +105,7 @@ public abstract class AccessCheckerTestBase {
   public void canAccessDirectResourceWithParamNotAuthorized() {
     // Query: GET /Observation/a-random-id?subject=PATIENT_AUTHORIZED
     when(requestMock.getResourceName()).thenReturn("Observation");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
     when(requestMock.getId()).thenReturn(new IdDt("a-random-id"));
     // This is to make sure that the presence of patient search params does not make any difference.
     Map<String, String[]> params = Maps.newHashMap();
@@ -115,6 +119,7 @@ public abstract class AccessCheckerTestBase {
   public void canAccessSearchQuery() {
     // Query: GET /Observation?subject=PATIENT_AUTHORIZED
     when(requestMock.getResourceName()).thenReturn("Observation");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
     Map<String, String[]> params = Maps.newHashMap();
     params.put("subject", new String[] {PATIENT_AUTHORIZED});
     when(requestMock.getParameters()).thenReturn(params);
@@ -126,6 +131,7 @@ public abstract class AccessCheckerTestBase {
   public void canAccessSearchQueryNotAuthorized() {
     // Query: GET /Observation?subject=PATIENT_AUTHORIZED
     when(requestMock.getResourceName()).thenReturn("Observation");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
     AccessChecker testInstance = getInstance();
     testInstance.checkAccess(requestMock).canAccess();
   }
@@ -218,6 +224,7 @@ public abstract class AccessCheckerTestBase {
     byte[] obsBytes = Resources.toByteArray(listUrl);
     when(requestMock.loadRequestContents()).thenReturn(obsBytes);
     when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.POST);
+
     AccessChecker testInstance = getInstance();
     assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(true));
   }
@@ -335,6 +342,7 @@ public abstract class AccessCheckerTestBase {
   @Test(expected = InvalidRequestException.class)
   public void canAccessSearchChaining() {
     when(requestMock.getResourceName()).thenReturn("Observation");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
     Map<String, String[]> params = Maps.newHashMap();
     params.put("subject:Patient.name", new String[] {"random-name"});
     when(requestMock.getParameters()).thenReturn(params);
@@ -345,6 +353,7 @@ public abstract class AccessCheckerTestBase {
   @Test(expected = InvalidRequestException.class)
   public void canAccessSearchReverseChaining() {
     when(requestMock.getResourceName()).thenReturn("Observation");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
     Map<String, String[]> params = Maps.newHashMap();
     params.put("subject", new String[] {PATIENT_AUTHORIZED});
     params.put("_has", new String[] {"something"});
@@ -356,6 +365,7 @@ public abstract class AccessCheckerTestBase {
   @Test(expected = InvalidRequestException.class)
   public void canAccessSearchInclude() {
     when(requestMock.getResourceName()).thenReturn("Observation");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
     Map<String, String[]> params = Maps.newHashMap();
     params.put("subject", new String[] {PATIENT_AUTHORIZED});
     params.put("_include", new String[] {"something"});
@@ -367,6 +377,7 @@ public abstract class AccessCheckerTestBase {
   @Test(expected = InvalidRequestException.class)
   public void canAccessSearchRevinclude() {
     when(requestMock.getResourceName()).thenReturn("Observation");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
     Map<String, String[]> params = Maps.newHashMap();
     params.put("subject", new String[] {PATIENT_AUTHORIZED});
     params.put("_revinclude", new String[] {"something"});

--- a/plugins/src/test/java/com/google/fhir/gateway/plugin/ListAccessCheckerTest.java
+++ b/plugins/src/test/java/com/google/fhir/gateway/plugin/ListAccessCheckerTest.java
@@ -248,6 +248,14 @@ public class ListAccessCheckerTest extends AccessCheckerTestBase {
   }
 
   @Test
+  public void canAccessBundleDeletePatient() throws IOException {
+    // Query: POST / -d @bundle_transaction_delete_patient.json
+    setUpFhirBundle("bundle_transaction_delete_patient.json");
+    AccessChecker testInstance = getInstance();
+    assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(true));
+  }
+
+  @Test
   public void canAccessPatchObservationUnauthorizedPatient() throws IOException {
     // Query: PATCH /Observation?subject=Patient/PATIENT_AUTHORIZED -d \
     // @test_obs_patch_unauthorized_patient.json

--- a/plugins/src/test/java/com/google/fhir/gateway/plugin/PatientAccessCheckerTest.java
+++ b/plugins/src/test/java/com/google/fhir/gateway/plugin/PatientAccessCheckerTest.java
@@ -20,6 +20,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
 
 import ca.uhn.fhir.rest.api.RequestTypeEnum;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import com.auth0.jwt.interfaces.Claim;
 import com.google.common.io.Resources;
 import com.google.fhir.gateway.PatientFinderImp;
 import com.google.fhir.gateway.interfaces.AccessChecker;
@@ -29,16 +31,22 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PatientAccessCheckerTest extends AccessCheckerTestBase {
 
+  @Mock protected Claim scopeClaimMock;
+
+  static final String DEFAULT_TEST_SCOPES_CLAIM = "patient/*.*";
+
   @Before
   public void setUp() throws IOException {
     when(jwtMock.getClaim(PatientAccessChecker.Factory.PATIENT_CLAIM)).thenReturn(claimMock);
+    when(jwtMock.getClaim(PatientAccessChecker.Factory.SCOPES_CLAIM)).thenReturn(scopeClaimMock);
     when(claimMock.asString()).thenReturn(PATIENT_AUTHORIZED);
-    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
+    when(scopeClaimMock.asString()).thenReturn(DEFAULT_TEST_SCOPES_CLAIM);
   }
 
   @Override
@@ -126,7 +134,38 @@ public class PatientAccessCheckerTest extends AccessCheckerTestBase {
     when(requestMock.getParameters())
         .thenReturn(Map.of("subject", new String[] {PATIENT_AUTHORIZED}));
     AccessChecker testInstance = getInstance();
+    assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(true));
+  }
 
+  @Test
+  public void canAccessPatchObservationNoValidPermissionForPatient() throws IOException {
+    // Query: PATCH /Observation?subject=Patient/PATIENT_AUTHORIZED -d @test_obs_patch.json
+    when(requestMock.getResourceName()).thenReturn("Observation");
+    when(requestMock.getParameters())
+        .thenReturn(Map.of("subject", new String[] {"be92a43f-de46-affa-b131-bbf9eea51140"}));
+    URL listUrl = Resources.getResource("test_obs_patch.json");
+    byte[] obsBytes = Resources.toByteArray(listUrl);
+    when(requestMock.loadRequestContents()).thenReturn(obsBytes);
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.PATCH);
+    when(scopeClaimMock.asString()).thenReturn("patient/Patient.write patient/Observation.read");
+    AccessChecker testInstance = getInstance();
+    assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(false));
+  }
+
+  @Test(expected = InvalidRequestException.class)
+  public void canAccessPutObservationInvalidPermissionScope() {
+    // Query: PUT /Observation -d @test_obs_unauthorized.json
+    when(requestMock.getResourceName()).thenReturn("Observation");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.PUT);
+    when(scopeClaimMock.asString()).thenReturn("patient/Observation.invalid");
+    AccessChecker testInstance = getInstance();
+    testInstance.checkAccess(requestMock).canAccess();
+  }
+
+  @Test
+  public void canAccessBundlePutPatient() throws IOException {
+    setUpFhirBundle("bundle_transaction_put_authorized_patient.json");
+    AccessChecker testInstance = getInstance();
     assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(true));
   }
 
@@ -137,7 +176,44 @@ public class PatientAccessCheckerTest extends AccessCheckerTestBase {
     when(requestMock.getParameters())
         .thenReturn(Map.of("subject", new String[] {PATIENT_NON_AUTHORIZED}));
     AccessChecker testInstance = getInstance();
+    assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(false));
+  }
 
+  @Test
+  public void canAccessBundlePutPatientNoValidPermission() throws IOException {
+    setUpFhirBundle("bundle_transaction_put_authorized_patient.json");
+    when(scopeClaimMock.asString()).thenReturn("patient/Observation.*");
+    AccessChecker testInstance = getInstance();
+    assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(false));
+  }
+
+  @Test
+  public void canAccessBundlePatchResources() throws IOException {
+    setUpFhirBundle("bundle_transaction_patch_authorized.json");
+    AccessChecker testInstance = getInstance();
+    assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(true));
+  }
+
+  @Test
+  public void canAccessBundlePatchResourcesNoValidPermission() throws IOException {
+    setUpFhirBundle("bundle_transaction_patch_authorized.json");
+    when(scopeClaimMock.asString()).thenReturn("patient/Observation.*");
+    AccessChecker testInstance = getInstance();
+    assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(false));
+  }
+
+  @Test
+  public void canAccessBundleSearchResources() throws IOException {
+    setUpFhirBundle("bundle_transaction_get_non_patient_authorized.json");
+    AccessChecker testInstance = getInstance();
+    assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(true));
+  }
+
+  @Test
+  public void canAccessBundleSearchResourcesNoValidPermission() throws IOException {
+    setUpFhirBundle("bundle_transaction_get_non_patient_authorized.json");
+    when(scopeClaimMock.asString()).thenReturn("patient/Observation.*");
+    AccessChecker testInstance = getInstance();
     assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(false));
   }
 }

--- a/plugins/src/test/java/com/google/fhir/gateway/plugin/PatientAccessCheckerTest.java
+++ b/plugins/src/test/java/com/google/fhir/gateway/plugin/PatientAccessCheckerTest.java
@@ -88,6 +88,14 @@ public class PatientAccessCheckerTest extends AccessCheckerTestBase {
   }
 
   @Test
+  public void canAccessBundleDeletePatientUnAuthorized() throws IOException {
+    // Query: POST / -d @bundle_transaction_delete_patient.json
+    setUpFhirBundle("bundle_transaction_delete_patient.json");
+    AccessChecker testInstance = getInstance();
+    assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(false));
+  }
+
+  @Test
   public void canAccessPatchObservationUnauthorizedPatient() throws IOException {
     // Query: PATCH /Observation?subject=Patient/PATIENT_AUTHORIZED -d \
     // @test_obs_patch_unauthorized_patient.json

--- a/plugins/src/test/java/com/google/fhir/gateway/plugin/SmartScopeCheckerTest.java
+++ b/plugins/src/test/java/com/google/fhir/gateway/plugin/SmartScopeCheckerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.fhir.gateway.plugin;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -8,92 +23,84 @@ import com.google.fhir.gateway.plugin.SmartFhirScope.Principal;
 import java.util.List;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class SmartScopeCheckerTest {
 
   @Test
   public void hasPermissionCreateObservationPatientPrincipal() {
-    SmartScopeChecker scopeChecker = new SmartScopeChecker(
-       SmartFhirScope.extractSmartFhirScopesFromTokens(
-           List.of(
-               "user/Encounter.read",
-               "patient/Observation.read",
-               "patient/Observation.write"
-           )
-       ),
-        Principal.PATIENT
-    );
-    assertThat(scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.CREATE), equalTo(true));
+    SmartScopeChecker scopeChecker =
+        new SmartScopeChecker(
+            SmartFhirScope.extractSmartFhirScopesFromTokens(
+                List.of(
+                    "user/Encounter.read",
+                    "patient/Observation.read",
+                    "patient/Observation.write")),
+            Principal.PATIENT);
+    assertThat(
+        scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.CREATE),
+        equalTo(true));
   }
 
   @Test
   public void hasPermissionCreateObservationPatientPrincipalNoValidScope() {
-    SmartScopeChecker scopeChecker = new SmartScopeChecker(
-        SmartFhirScope.extractSmartFhirScopesFromTokens(
-            List.of(
-                "user/Observation.create",
-                "patient/Observation.read"
-            )
-        ),
-        Principal.PATIENT
-    );
-    assertThat(scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.CREATE), equalTo(false));
+    SmartScopeChecker scopeChecker =
+        new SmartScopeChecker(
+            SmartFhirScope.extractSmartFhirScopesFromTokens(
+                List.of("user/Observation.create", "patient/Observation.read")),
+            Principal.PATIENT);
+    assertThat(
+        scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.CREATE),
+        equalTo(false));
   }
 
   @Test
   public void hasPermissionReadObservationPatientPrincipalAllResources() {
-    SmartScopeChecker scopeChecker = new SmartScopeChecker(
-        SmartFhirScope.extractSmartFhirScopesFromTokens(
-            List.of(
-                "user/*.read",
-                "patient/Observation.write"
-            )
-        ),
-        Principal.PATIENT
-    );
-    assertThat(scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.READ), equalTo(false));
+    SmartScopeChecker scopeChecker =
+        new SmartScopeChecker(
+            SmartFhirScope.extractSmartFhirScopesFromTokens(
+                List.of("user/*.read", "patient/Observation.write")),
+            Principal.PATIENT);
+    assertThat(
+        scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.READ),
+        equalTo(false));
   }
 
   @Test
   public void hasPermissionDeleteObservationPatientPrincipalAllResources() {
-    SmartScopeChecker scopeChecker = new SmartScopeChecker(
-        SmartFhirScope.extractSmartFhirScopesFromTokens(
-            List.of(
-                "patient/*.read",
-                "patient/Observation.write"
-            )
-        ),
-        Principal.PATIENT
-    );
-    assertThat(scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.DELETE), equalTo(true));
+    SmartScopeChecker scopeChecker =
+        new SmartScopeChecker(
+            SmartFhirScope.extractSmartFhirScopesFromTokens(
+                List.of("patient/*.read", "patient/Observation.write")),
+            Principal.PATIENT);
+    assertThat(
+        scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.DELETE),
+        equalTo(true));
   }
 
   @Test
   public void hasPermissionCreateObservationV2Scopes() {
-    SmartScopeChecker scopeChecker = new SmartScopeChecker(
-        SmartFhirScope.extractSmartFhirScopesFromTokens(
-            List.of(
-                "patient/*.rs",
-                "patient/Observation.u"
-            )
-        ),
-        Principal.PATIENT
-    );
-    assertThat(scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.CREATE), equalTo(false));
+    SmartScopeChecker scopeChecker =
+        new SmartScopeChecker(
+            SmartFhirScope.extractSmartFhirScopesFromTokens(
+                List.of("patient/*.rs", "patient/Observation.u")),
+            Principal.PATIENT);
+    assertThat(
+        scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.CREATE),
+        equalTo(false));
   }
 
   @Test
   public void hasPermissionDeleteObservationV2Scopes() {
-    SmartScopeChecker scopeChecker = new SmartScopeChecker(
-        SmartFhirScope.extractSmartFhirScopesFromTokens(
-            List.of(
-                "user/*.rs",
-                "user/Observation.cr"
-            )
-        ),
-        Principal.PATIENT
-    );
-    assertThat(scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.DELETE), equalTo(false));
+    SmartScopeChecker scopeChecker =
+        new SmartScopeChecker(
+            SmartFhirScope.extractSmartFhirScopesFromTokens(
+                List.of("user/*.rs", "user/Observation.cr")),
+            Principal.PATIENT);
+    assertThat(
+        scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.DELETE),
+        equalTo(false));
   }
-
 }

--- a/plugins/src/test/java/com/google/fhir/gateway/plugin/SmartScopeCheckerTest.java
+++ b/plugins/src/test/java/com/google/fhir/gateway/plugin/SmartScopeCheckerTest.java
@@ -1,0 +1,99 @@
+package com.google.fhir.gateway.plugin;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.google.fhir.gateway.plugin.SmartFhirScope.Permission;
+import com.google.fhir.gateway.plugin.SmartFhirScope.Principal;
+import java.util.List;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.junit.Test;
+
+public class SmartScopeCheckerTest {
+
+  @Test
+  public void hasPermissionCreateObservationPatientPrincipal() {
+    SmartScopeChecker scopeChecker = new SmartScopeChecker(
+       SmartFhirScope.extractSmartFhirScopesFromTokens(
+           List.of(
+               "user/Encounter.read",
+               "patient/Observation.read",
+               "patient/Observation.write"
+           )
+       ),
+        Principal.PATIENT
+    );
+    assertThat(scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.CREATE), equalTo(true));
+  }
+
+  @Test
+  public void hasPermissionCreateObservationPatientPrincipalNoValidScope() {
+    SmartScopeChecker scopeChecker = new SmartScopeChecker(
+        SmartFhirScope.extractSmartFhirScopesFromTokens(
+            List.of(
+                "user/Observation.create",
+                "patient/Observation.read"
+            )
+        ),
+        Principal.PATIENT
+    );
+    assertThat(scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.CREATE), equalTo(false));
+  }
+
+  @Test
+  public void hasPermissionReadObservationPatientPrincipalAllResources() {
+    SmartScopeChecker scopeChecker = new SmartScopeChecker(
+        SmartFhirScope.extractSmartFhirScopesFromTokens(
+            List.of(
+                "user/*.read",
+                "patient/Observation.write"
+            )
+        ),
+        Principal.PATIENT
+    );
+    assertThat(scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.READ), equalTo(false));
+  }
+
+  @Test
+  public void hasPermissionDeleteObservationPatientPrincipalAllResources() {
+    SmartScopeChecker scopeChecker = new SmartScopeChecker(
+        SmartFhirScope.extractSmartFhirScopesFromTokens(
+            List.of(
+                "patient/*.read",
+                "patient/Observation.write"
+            )
+        ),
+        Principal.PATIENT
+    );
+    assertThat(scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.DELETE), equalTo(true));
+  }
+
+  @Test
+  public void hasPermissionCreateObservationV2Scopes() {
+    SmartScopeChecker scopeChecker = new SmartScopeChecker(
+        SmartFhirScope.extractSmartFhirScopesFromTokens(
+            List.of(
+                "patient/*.rs",
+                "patient/Observation.u"
+            )
+        ),
+        Principal.PATIENT
+    );
+    assertThat(scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.CREATE), equalTo(false));
+  }
+
+  @Test
+  public void hasPermissionDeleteObservationV2Scopes() {
+    SmartScopeChecker scopeChecker = new SmartScopeChecker(
+        SmartFhirScope.extractSmartFhirScopesFromTokens(
+            List.of(
+                "user/*.rs",
+                "user/Observation.cr"
+            )
+        ),
+        Principal.PATIENT
+    );
+    assertThat(scopeChecker.hasPermission(ResourceType.Observation.name(), Permission.DELETE), equalTo(false));
+  }
+
+}

--- a/plugins/src/test/resources/bundle_transaction_delete_non_patient.json
+++ b/plugins/src/test/resources/bundle_transaction_delete_non_patient.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "request": {
+        "method": "DELETE",
+        "url": "Observation?patient=be92a43f-de46-affa-b131-bbf9eea51140&_id=4047"
+      }
+    }
+  ]
+}

--- a/plugins/src/test/resources/bundle_transaction_delete_patient.json
+++ b/plugins/src/test/resources/bundle_transaction_delete_patient.json
@@ -1,0 +1,34 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "name": [
+          {
+            "family": "Smith",
+            "given": [
+              "Darcy"
+            ]
+          }
+        ],
+        "gender": "female",
+        "address": [
+          {
+            "line": [
+              "123 Main St."
+            ],
+            "city": "Anycity",
+            "state": "CA",
+            "postalCode": "12345"
+          }
+        ]
+      },
+      "request": {
+        "method": "DELETE",
+        "url": "Patient/be92a43f-de46-affa-b131-bbf9eea51140"
+      }
+    }
+  ]
+}

--- a/plugins/src/test/resources/bundle_transaction_delete_patient_unauthorized.json
+++ b/plugins/src/test/resources/bundle_transaction_delete_patient_unauthorized.json
@@ -27,7 +27,7 @@
       },
       "request": {
         "method": "DELETE",
-        "url": "Patient/7890"
+        "url": "Patient/patient-non-authorized"
       }
     }
   ]

--- a/plugins/src/test/resources/bundle_transaction_get_non_patient_authorized.json
+++ b/plugins/src/test/resources/bundle_transaction_get_non_patient_authorized.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "request": {
+        "method": "GET",
+        "url": "Encounter?patient=be92a43f-de46-affa-b131-bbf9eea51140"
+      }
+    }
+  ]
+}

--- a/plugins/src/test/resources/bundle_transaction_patch_authorized.json
+++ b/plugins/src/test/resources/bundle_transaction_patch_authorized.json
@@ -1,0 +1,30 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "fullUrl": "Patient/be92a43f-de46-affa-b131-bbf9eea51140",
+      "resource": {
+        "resourceType": "Binary",
+        "contentType": "application/json-patch+json",
+        "data": "WyB7ICJvcCI6InJlcGxhY2UiLCAicGF0aCI6Ii9hY3RpdmUiLCAidmFsdWUiOnRydWUgfSBd"
+      },
+      "request": {
+        "method": "PATCH",
+        "url": "Patient/be92a43f-de46-affa-b131-bbf9eea51140"
+      }
+    },
+    {
+      "fullUrl": "Observation/observation-jamess-bond-id-1",
+      "resource": {
+        "resourceType": "Binary",
+        "contentType": "application/json-patch+json",
+        "data": "WwogIHsKICAgICJvcCI6ICJyZXBsYWNlIiwKICAgICJwYXRoIjogIi9zdWJqZWN0L3JlZmVyZW5jZSIsCiAgICAidmFsdWUiOiAiUGF0aWVudC9iZTkyYTQzZi1kZTQ2LWFmZmEtYjEzMS1iYmY5ZWVhNTExNDAiCiAgfSx7CiAgIm9wIjogImFkZCIsCiAgInBhdGgiOiAiL3BlcmZvcm1lciIsCiAgInZhbHVlIjpbXQp9LAogIHsKICAgICJvcCI6ICJhZGQiLAogICAgInBhdGgiIDogIi9wZXJmb3JtZXIvMCIsCiAgICAidmFsdWUiIDogewogICAgICAicmVmZXJlbmNlIjogIlBhdGllbnQvbWljaGFlbCIKICAgIH0KICB9Cl0="
+      },
+      "request": {
+        "method": "PATCH",
+        "url": "Observation?_id=observation-jamess-bond-id-1&subject=Patient/be92a43f-de46-affa-b131-bbf9eea51140"
+      }
+    }
+  ]
+}

--- a/plugins/src/test/resources/bundle_transaction_put_authorized_patient.json
+++ b/plugins/src/test/resources/bundle_transaction_put_authorized_patient.json
@@ -1,0 +1,34 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "name": [
+          {
+            "family": "Smith",
+            "given": [
+              "Darcy"
+            ]
+          }
+        ],
+        "gender": "female",
+        "address": [
+          {
+            "line": [
+              "123 Main St."
+            ],
+            "city": "Anycity",
+            "state": "CA",
+            "postalCode": "12345"
+          }
+        ]
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/be92a43f-de46-affa-b131-bbf9eea51140"
+      }
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,18 +19,55 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>9</version>
+  </parent>
+
   <groupId>com.google.fhir.gateway</groupId>
   <artifactId>fhir-gateway</artifactId>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
   <packaging>pom</packaging>
 
-  <name>FHIR Access Proxy</name>
+  <name>FHIR Information Gateway</name>
+  <description>A pluggable access-control gateway for any generic FHIR server.</description>
+  <url>https://github.com/google/fhir-gateway</url>
   <inceptionYear>2021</inceptionYear>
+
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
   <modules>
     <module>exec</module>
     <module>plugins</module>
     <module>server</module>
   </modules>
+
+  <scm>
+    <connection>scm:git:git://github.com/google/fhir-gateway.git</connection>
+    <developerConnection>scm:git:ssh://github.com:google/fhir-gateway.git</developerConnection>
+    <url>https://github.com/google/fhir-gateway/tree/main</url>
+  </scm>
+
+  <!-- For release documentation see:
+    https://central.sonatype.org/publish/publish-maven/
+    Note, although it suggests new projects should use s01.oss.sonatype.org but
+    with our sonatype.org credentials, it fails with a "Forbidden" message. -->
+  <distributionManagement>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
 
   <properties>
     <hapifhir_version>6.2.5</hapifhir_version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
   </modules>
 
   <properties>
-    <hapifhir_version>6.2.4</hapifhir_version>
+    <hapifhir_version>6.2.5</hapifhir_version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spotless.version>2.30.0</spotless.version>
+    <spotless.version>2.32.0</spotless.version>
     <root.basedir>${project.basedir}</root.basedir>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.0.0</version>
+      <version>5.1.1</version>
       <scope>test</scope>
     </dependency>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.fhir.gateway</groupId>
     <artifactId>fhir-gateway</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
   </parent>
 
   <artifactId>server</artifactId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.14.0</version>
+      <version>1.15.0</version>
     </dependency>
 
     <!-- For HTTP Client -->
@@ -127,7 +127,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.24</version>
+      <version>1.18.26</version>
     </dependency>
 
   </dependencies>

--- a/server/src/main/java/com/google/fhir/gateway/BundlePatients.java
+++ b/server/src/main/java/com/google/fhir/gateway/BundlePatients.java
@@ -21,28 +21,26 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import java.util.List;
 import java.util.Set;
+import lombok.Getter;
 
+@Getter
 public class BundlePatients {
 
   private final ImmutableList<ImmutableSet<String>> referencedPatients;
   private final ImmutableSet<String> updatedPatients;
   private final boolean patientsToCreate;
 
+  private final ImmutableSet<String> deletedPatients;
+
   private BundlePatients(
       List<ImmutableSet<String>> referencedPatients,
       Set<String> updatedPatients,
+      Set<String> deletedPatients,
       boolean patientIdsToCreate) {
     this.referencedPatients = ImmutableList.copyOf(referencedPatients);
     this.updatedPatients = ImmutableSet.copyOf(updatedPatients);
+    this.deletedPatients = ImmutableSet.copyOf(deletedPatients);
     this.patientsToCreate = patientIdsToCreate;
-  }
-
-  public ImmutableList<ImmutableSet<String>> getReferencedPatients() {
-    return referencedPatients;
-  }
-
-  public ImmutableSet<String> getUpdatedPatients() {
-    return updatedPatients;
   }
 
   public boolean areTherePatientToCreate() {
@@ -51,11 +49,18 @@ public class BundlePatients {
 
   public static class BundlePatientsBuilder {
     private final Set<String> updatedPatients = Sets.newHashSet();
+    private final Set<String> deletedPatients = Sets.newHashSet();
     private final List<ImmutableSet<String>> referencedPatients = Lists.newArrayList();
     private boolean patientsToCreate = false;
 
     public BundlePatientsBuilder addUpdatePatients(Set<String> patientsToUpdate) {
       updatedPatients.addAll(patientsToUpdate);
+      return this;
+    }
+
+    public BundlePatientsBuilder addDeletedPatients(Set<String> patientsToDelete) {
+      deletedPatients.addAll(patientsToDelete);
+      addReferencedPatients(patientsToDelete);
       return this;
     }
 
@@ -83,7 +88,8 @@ public class BundlePatients {
     }
 
     public BundlePatients build() {
-      return new BundlePatients(referencedPatients, updatedPatients, patientsToCreate);
+      return new BundlePatients(
+          referencedPatients, updatedPatients, deletedPatients, patientsToCreate);
     }
   }
 }

--- a/server/src/main/java/com/google/fhir/gateway/FhirUtil.java
+++ b/server/src/main/java/com/google/fhir/gateway/FhirUtil.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.apache.http.HttpResponse;
+import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.ResourceType;
@@ -60,6 +61,15 @@ public class FhirUtil {
 
   public static boolean isValidId(String id) {
     return ID_PATTERN.matcher(id).matches();
+  }
+
+  public static boolean isValidFhirResourceType(String resourceType) {
+    try {
+      ResourceType.fromCode(resourceType);
+      return true;
+    } catch (FHIRException fe) {
+      return false;
+    }
   }
 
   public static String checkIdOrFail(String idPart) {


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->

## Description of what I changed

Added support for SMART on FHIR patient scope checks in PatientAccessChecker
Issue #41 

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Tested the various scenarios of access control by generating access tokens with relevant SMART-on-FHIR patient scopes in the `scope` claim of the access token. 

For example: 
An access token is issued with create and update permissions for Observation and reading a patient profile on issuing the curl command to the keycloak server 
`curl -X POST -d 'client_id=growth_chart' -d 'username=testuser'   -d 'password=testpass' -d 'grant_type=password' -d 'scope=launch/patient patient/Observation.write patient/Patient.read' "http://localhost:9080/auth/realms/test-smart/protocol/openid-connect/token"`

A PUT operation for updating an existing Observation resource is successful 

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE]().

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
