### PR TITLE
Setting only required default scopes for test realm

### DIFF
--- a/docker/keycloak/keycloak_setup.sh
+++ b/docker/keycloak/keycloak_setup.sh
@@ -79,18 +79,9 @@ sh kcadm.sh update events/config -r ${REALM} \
 # app developed by the FHIR SDK: https://github.com/google/android-fhir/
 CID=$(sh kcadm.sh create clients -r ${REALM} -s clientId=my-fhir-client \
   -s publicClient=true -s directAccessGrantsEnabled=true \
+  -s defaultClientScopes='["profile"]' \
   -s redirectUris='["com.google.fhir.examples.demo:/oauth2redirect"]' -i)
 echo "Created the new 'my-fhir-client' client ${CID}"
-
-# TODO remove the group setup after all proxy uses are upgraded.
-# Create a group which will be returned in `group` claim of issued tokens.
-sh kcadm.sh create groups -r ${REALM} -s name=fhirUser
-
-# Add the protocol-mapper for adding `group` claim.
-sh kcadm.sh create -r ${REALM} clients/${CID}/protocol-mappers/models/ \
-  -s name=group-fhir  -s protocolMapper=oidc-group-membership-mapper \
-  -s protocol=openid-connect \
-  -s config='{"full.path":"false","id.token.claim":"true","access.token.claim":"true","claim.name":"group","userinfo.token.claim":"true"}'
 
 # Create a protocol-mapper for `patient_list` user attribute.
 sh kcadm.sh create -r ${REALM} clients/${CID}/protocol-mappers/models/ \
@@ -100,7 +91,7 @@ sh kcadm.sh create -r ${REALM} clients/${CID}/protocol-mappers/models/ \
 
 # Create the test user; set its password, group, etc.
 sh kcadm.sh create users -r ${REALM} -s username=${TEST_USER} \
-  -s groups='["fhirUser"]' -s enabled=true \
+  -s enabled=true \
   -s attributes='{"patient_list":"patient-list-example"}' \
   -s credentials='[{"type":"password","value":"'${TEST_PASS}'","temporary":false}]'
 
@@ -129,7 +120,7 @@ echo "Created the new 'growth_chart' client ${SCID}"
 
 # Create a new user in this realm with the same user credentials as before.
 sh kcadm.sh create users -r ${SMART_REALM} -s username=${TEST_USER} \
-  -s groups='["fhirUser"]' -s enabled=true \
+  -s enabled=true \
   -s attributes='{"resourceId":"'${SMART_PATIENT_ID}'"}' \
   -s credentials='[{"type":"password","value":"'${TEST_PASS}'","temporary":false}]'
 


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->

## Description of what I changed
#101 
To remove the extra claims regarding roles and emails in the `test` realm that we setup for sample tokens, explicitly set the `defaultClientScopes` while creating the realm. Also remove the group protocol mapper for this realm.

For `test-smart`, the extension that we use to enable SMART-on-FHIR already takes care of setting these claims up to the requirement.

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

After the required changes, tested by issuing a token for both the realms. 

For `test` realm, the token's payload when decoded used to look like this before: 
```
{
  "exp": 1678093320,
  "iat": 1678093020,
  "jti": "1c826158-517a-434d-82c4-073f7992518e",
  "iss": "http://104.198.226.164:9080/auth/realms/test",
  "aud": "account",
  "sub": "a1d4b0ea-4c47-44b8-8af2-496ea1ed46f0",
  "typ": "Bearer",
  "azp": "my-fhir-client",
  "session_state": "277c6af2-dbe9-4ae2-91eb-9be2cfb4f9d5",
  "acr": "1",
  "realm_access": {
    "roles": [
      "default-roles-test",
      "offline_access",
      "uma_authorization"
    ]
  },
  "resource_access": {
    "account": {
      "roles": [
        "manage-account",
        "manage-account-links",
        "view-profile"
      ]
    }
  },
  "scope": "profile email",
  "sid": "277c6af2-dbe9-4ae2-91eb-9be2cfb4f9d5",
  "email_verified": false,
  "patient_list": "4156970",
  "preferred_username": "testuser",
  "group": [
    "fhirUser"
  ]
}
```

After the changes it looks like this:
```
{
  "exp": 1678091062,
  "iat": 1678090762,
  "jti": "5cdcd82c-bef6-462d-baa3-0a5f3a0fd7c1",
  "iss": "http://localhost:9080/auth/realms/test",
  "sub": "7cbd5274-c1bb-4041-b8de-454c336b179a",
  "typ": "Bearer",
  "azp": "my-fhir-client",
  "session_state": "39d52772-5322-4561-8db3-78d8b6dbf2b1",
  "scope": "profile",
  "sid": "39d52772-5322-4561-8db3-78d8b6dbf2b1",
  "patient_list": "patient-list-example",
  "preferred_username": "testuser"
}
```

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [ ] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [ ] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [ ] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [ ] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [ ] All new and existing **tests passed**.
- [ ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
