### PR TITLE
Unauthenticated queries support in AllowedQueriesChecker

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,13 @@ The configuration parameters are provided through environment variables:
 
 - `ALLOWED_QUERIES_FILE`: A list of URL requests that should bypass the access
   checker and always be allowed.
-  [`AllowedQueriesChecker`](https://github.com/google/fhir-gateway/blob/main/server/src/main/java/com/google/fhir/gateway/AllowedQueriesChecker.java)
-  is a special `AccessChecker` that compares the incoming request with a
-  configured set of allowed-queries. The intended use of this checker is to
-  override all other access-checkers for certain user-defined criteria. The user
-  defines their criteria in a config file and if the URL query matches an entry
-  in the config file, access is granted. An example of this is
+  [`AllowedQueriesChecker`](https://github.com/google/fhir-gateway/blob/main/server/src/main/java/com/google/fhir/gateway/AllowedQueriesChecker.java)compares
+  the incoming request with a configured set of allowed-queries. The intended
+  use of this checker is to override all other access-checkers for certain
+  user-defined criteria. The user defines their criteria in a config file and if
+  the URL query matches an entry in the config file, access is granted.
+  [AllowedQueriesConfig](https://github.com/google/fhir-gateway/blob/main/server/src/main/java/com/google/fhir/gateway/AllowedQueriesConfig.java)
+  provides all the supported configurations. An example of this is
   [`hapi_page_url_allowed_queries.json`](https://github.com/google/fhir-gateway/blob/main/resources/hapi_page_url_allowed_queries.json).
   To use this file with `ALLOWED_QUERIES_FILE`:
 

--- a/README.md
+++ b/README.md
@@ -106,11 +106,12 @@ The configuration parameters are provided through environment variables:
 
 - `ALLOWED_QUERIES_FILE`: A list of URL requests that should bypass the access
   checker and always be allowed.
-  [`AllowedQueriesChecker`](https://github.com/google/fhir-gateway/blob/main/server/src/main/java/com/google/fhir/gateway/AllowedQueriesChecker.java)compares
-  the incoming request with a configured set of allowed-queries. The intended
-  use of this checker is to override all other access-checkers for certain
-  user-defined criteria. The user defines their criteria in a config file and if
-  the URL query matches an entry in the config file, access is granted.
+  [`AllowedQueriesChecker`](https://github.com/google/fhir-gateway/blob/main/server/src/main/java/com/google/fhir/gateway/AllowedQueriesChecker.java)
+  compares the incoming request with a configured set of allowed-queries. The
+  intended use of this checker is to override all other access-checkers for
+  certain user-defined criteria. The user defines their criteria in a config
+  file and if the URL query matches an entry in the config file, access is
+  granted.
   [AllowedQueriesConfig](https://github.com/google/fhir-gateway/blob/main/server/src/main/java/com/google/fhir/gateway/AllowedQueriesConfig.java)
   provides all the supported configurations. An example of this is
   [`hapi_page_url_allowed_queries.json`](https://github.com/google/fhir-gateway/blob/main/resources/hapi_page_url_allowed_queries.json).

--- a/server/src/main/java/com/google/fhir/gateway/AllowedQueriesChecker.java
+++ b/server/src/main/java/com/google/fhir/gateway/AllowedQueriesChecker.java
@@ -65,7 +65,7 @@ class AllowedQueriesChecker {
       return NoOpAccessDecision.accessDenied();
     }
     for (AllowedQueryEntry entry : config.entries) {
-      if (entry.isAllowUnAuthenticatedRequests() && requestMatches(requestDetails, entry)) {
+      if (entry.isAllowUnauthenticatedRequests() && requestMatches(requestDetails, entry)) {
         return NoOpAccessDecision.accessGranted();
       }
     }

--- a/server/src/main/java/com/google/fhir/gateway/AllowedQueriesConfig.java
+++ b/server/src/main/java/com/google/fhir/gateway/AllowedQueriesConfig.java
@@ -38,6 +38,8 @@ class AllowedQueriesConfig {
     // If true, this means all parameters in `queryParams` are required,  i.e., none are optional.
     private boolean allParamsRequired;
 
+    private boolean allowUnAuthenticatedRequests;
+
     @Override
     public String toString() {
       String builder =
@@ -48,7 +50,9 @@ class AllowedQueriesConfig {
               + " allowExtraParams="
               + allowExtraParams
               + " allParamsRequired="
-              + allParamsRequired;
+              + allParamsRequired
+              + " allowUnAuthenticatedRequests="
+              + allowUnAuthenticatedRequests;
       return builder;
     }
   }

--- a/server/src/main/java/com/google/fhir/gateway/AllowedQueriesConfig.java
+++ b/server/src/main/java/com/google/fhir/gateway/AllowedQueriesConfig.java
@@ -38,7 +38,7 @@ class AllowedQueriesConfig {
     // If true, this means all parameters in `queryParams` are required,  i.e., none are optional.
     private boolean allParamsRequired;
 
-    private boolean allowUnAuthenticatedRequests;
+    private boolean allowUnauthenticatedRequests;
 
     @Override
     public String toString() {
@@ -51,8 +51,8 @@ class AllowedQueriesConfig {
               + allowExtraParams
               + " allParamsRequired="
               + allParamsRequired
-              + " allowUnAuthenticatedRequests="
-              + allowUnAuthenticatedRequests;
+              + " allowUnauthenticatedRequests="
+              + allowUnauthenticatedRequests;
       return builder;
     }
   }

--- a/server/src/main/java/com/google/fhir/gateway/BearerAuthorizationInterceptor.java
+++ b/server/src/main/java/com/google/fhir/gateway/BearerAuthorizationInterceptor.java
@@ -218,6 +218,12 @@ public class BearerAuthorizationInterceptor {
       // Abuse of this open endpoint should be blocked by DDOS prevention means.
       return CapabilityPostProcessor.getInstance(server.getFhirContext());
     }
+    RequestDetailsReader requestDetailsReader = new RequestDetailsToReader(requestDetails);
+    AccessDecision unauthenticatedQueriesDecision =
+        allowedQueriesChecker.checkUnAuthenticatedAccess(requestDetailsReader);
+    if (unauthenticatedQueriesDecision.canAccess()) {
+      return unauthenticatedQueriesDecision;
+    }
     // Check the Bearer token to be a valid JWT with required claims.
     String authHeader = requestDetails.getHeader("Authorization");
     if (authHeader == null) {
@@ -226,7 +232,6 @@ public class BearerAuthorizationInterceptor {
     }
     DecodedJWT decodedJwt = decodeAndVerifyBearerToken(authHeader);
     FhirContext fhirContext = server.getFhirContext();
-    RequestDetailsReader requestDetailsReader = new RequestDetailsToReader(requestDetails);
     AccessDecision allowedQueriesDecision = allowedQueriesChecker.checkAccess(requestDetailsReader);
     if (allowedQueriesDecision.canAccess()) {
       return allowedQueriesDecision;

--- a/server/src/test/java/com/google/fhir/gateway/AllowedQueriesCheckerTest.java
+++ b/server/src/test/java/com/google/fhir/gateway/AllowedQueriesCheckerTest.java
@@ -74,6 +74,16 @@ public class AllowedQueriesCheckerTest {
   }
 
   @Test
+  public void validUnAuthenticatedQuery() throws IOException {
+    when(requestMock.getRequestPath()).thenReturn("Composition");
+    URL configFileUrl = Resources.getResource("allowed_unauthenticated_queries.json");
+
+    AllowedQueriesChecker testInstance = new AllowedQueriesChecker(configFileUrl.getPath());
+
+    assertThat(testInstance.checkUnAuthenticatedAccess(requestMock).canAccess(), equalTo(true));
+  }
+
+  @Test
   public void noMatchForObservationQuery() throws IOException {
     // Query: GET /Observation?_getpages=A_PAGE_ID
     when(requestMock.getRequestPath()).thenReturn("/Observation");
@@ -116,5 +126,15 @@ public class AllowedQueriesCheckerTest {
     URL configFileUrl = Resources.getResource("hapi_page_url_allowed_queries.json");
     AllowedQueriesChecker testInstance = new AllowedQueriesChecker(configFileUrl.getPath());
     assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(false));
+  }
+
+  @Test
+  public void denyUnAuthenticatedQuery() throws IOException {
+    when(requestMock.getRequestPath()).thenReturn("Patient");
+    URL configFileUrl = Resources.getResource("allowed_unauthenticated_queries.json");
+
+    AllowedQueriesChecker testInstance = new AllowedQueriesChecker(configFileUrl.getPath());
+
+    assertThat(testInstance.checkUnAuthenticatedAccess(requestMock).canAccess(), equalTo(false));
   }
 }

--- a/server/src/test/java/com/google/fhir/gateway/BearerAuthorizationInterceptorTest.java
+++ b/server/src/test/java/com/google/fhir/gateway/BearerAuthorizationInterceptorTest.java
@@ -203,7 +203,10 @@ public class BearerAuthorizationInterceptorTest {
     JWTCreator.Builder jwtBuilder = JWT.create().withIssuer(TOKEN_ISSUER);
     String jwt = signJwt(jwtBuilder);
     when(requestMock.getHeader("Authorization")).thenReturn("Bearer " + jwt);
+    setupFhirResponse(fhirStoreResponse);
+  }
 
+  private void setupFhirResponse(String fhirStoreResponse) throws IOException {
     IRestfulResponse proxyResponseMock = Mockito.mock(IRestfulResponse.class);
     when(requestMock.getResponse()).thenReturn(proxyResponseMock);
     when(proxyResponseMock.getResponseWriter(
@@ -324,13 +327,13 @@ public class BearerAuthorizationInterceptorTest {
   }
 
   @Test
-  public void authorizeAllowedUnAuthenticatedRequest() throws IOException {
+  public void authorizeAllowedUnauthenticatedRequest() throws IOException {
     // Changing the access-checker to something that always denies except the allowed queries
     testInstance =
         createTestInstance(
             false, Resources.getResource("allowed_unauthenticated_queries.json").getPath());
     String responseJson = "{\"resourceType\": \"Bundle\"}";
-    authorizeRequestCommonSetUp(responseJson);
+    setupFhirResponse(responseJson);
     when(requestMock.getRequestPath()).thenReturn("Composition");
 
     testInstance.authorizeRequest(requestMock);

--- a/server/src/test/resources/allowed_unauthenticated_queries.json
+++ b/server/src/test/resources/allowed_unauthenticated_queries.json
@@ -1,0 +1,11 @@
+{
+  "entries": [
+    {
+      "path": "Composition",
+      "allowUnAuthenticatedRequests": true,
+      "queryParams": {
+        "_getpages": "ANY_VALUE"
+      }
+    }
+  ]
+}

--- a/server/src/test/resources/allowed_unauthenticated_queries.json
+++ b/server/src/test/resources/allowed_unauthenticated_queries.json
@@ -2,7 +2,7 @@
   "entries": [
     {
       "path": "Composition",
-      "allowUnAuthenticatedRequests": true,
+      "allowUnauthenticatedRequests": true,
       "queryParams": {
         "_getpages": "ANY_VALUE"
       }


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->

## Description of what I changed
Unauthenticated queries support in AllowedQueriesChecker.

- Added a new config parameter in AllowedQueriesConfig to allow unauthenticated requests for the matching queries
- AllowedQueriesChecker doesn't need to implement the AccessChecker interface. Removed this redundant inheritance. 
- Updated BearerAuthorizationInterceptor to allow requests without a valid token based on queries checker



https://github.com/google/fhir-gateway/issues/115

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED: Verified locally by allowing unauthenticated queries for Composition resource and tested the API call without a valid access token. 

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
