### PR TITLE
Initialize default empty map of queryParms in AllowedQueryEntry

### DIFF
--- a/server/src/main/java/com/google/fhir/gateway/AllowedQueriesConfig.java
+++ b/server/src/main/java/com/google/fhir/gateway/AllowedQueriesConfig.java
@@ -16,6 +16,7 @@
 package com.google.fhir.gateway;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.Getter;
@@ -44,6 +45,10 @@ class AllowedQueriesConfig {
     private boolean allParamsRequired;
 
     private boolean allowUnauthenticatedRequests;
+
+    AllowedQueryEntry() {
+      queryParams = new HashMap<>();
+    }
 
     @Override
     public String toString() {

--- a/server/src/test/resources/allowed_queries_with_path_type.json
+++ b/server/src/test/resources/allowed_queries_with_path_type.json
@@ -1,19 +1,13 @@
 {
   "entries": [
     {
-      "path": "Observation",
-      "queryParams": {
-      }
+      "path": "Observation"
     },
     {
-      "path": "Composition/ANY_VALUE",
-      "queryParams": {
-      }
+      "path": "Composition/ANY_VALUE"
     },
     {
       "path": "Encounter",
-      "queryParams": {
-      },
       "requestType" : "Get"
     }
   ]


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->

## Description of what I changed

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Please replace this with a description of how you tested your PR beyond the
automated e2e/unit tests.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [ ] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [ ] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [ ] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [ ] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [ ] All new and existing **tests passed**.
- [ ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
