### PR TITLE
Patient finder support for extracting multiple patient IDs in query params

### DIFF
--- a/plugins/src/main/java/com/google/fhir/gateway/plugin/ListAccessChecker.java
+++ b/plugins/src/main/java/com/google/fhir/gateway/plugin/ListAccessChecker.java
@@ -109,7 +109,7 @@ public class ListAccessChecker implements AccessChecker {
   // may want to revisit it in the future.
   // Note patientIds are expected NOT to include the `Patient/` prefix (pure IDs only).
   private boolean serverListIncludesAnyPatient(Set<String> patientIds) {
-    if (patientIds == null) {
+    if (patientIds == null || patientIds.isEmpty()) {
       return false;
     }
     // TODO consider using the HAPI FHIR client instead; see:
@@ -123,7 +123,7 @@ public class ListAccessChecker implements AccessChecker {
   // Note patientIds are expected to include the `Patient/` prefix.
   // TODO fix the above inconsistency with `serverListIncludesAnyPatient`.
   private boolean serverListIncludesAllPatients(Set<String> patientIds) {
-    if (patientIds == null) {
+    if (patientIds == null || patientIds.isEmpty()) {
       return false;
     }
     String patientParam = queryBuilder(patientIds, "item=", "&");
@@ -190,8 +190,10 @@ public class ListAccessChecker implements AccessChecker {
       }
       return NoOpAccessDecision.accessDenied();
     }
-    String patientId = patientFinder.findPatientFromParams(requestDetails);
-    return new NoOpAccessDecision(serverListIncludesAnyPatient(Sets.newHashSet(patientId)));
+    Set<String> patientIds = patientFinder.findPatientsFromParams(requestDetails);
+    Set<String> patientQueries = Sets.newHashSet();
+    patientIds.forEach(patientId -> patientQueries.add(String.format("Patient/%s", patientId)));
+    return new NoOpAccessDecision(serverListIncludesAllPatients(patientQueries));
   }
 
   private AccessDecision processPost(RequestDetailsReader requestDetails) {
@@ -238,8 +240,10 @@ public class ListAccessChecker implements AccessChecker {
     // TODO(https://github.com/google/fhir-access-proxy/issues/63):Support direct resource deletion.
 
     // There should be a patient id in search params; the param name is based on the resource.
-    String patientId = patientFinder.findPatientFromParams(requestDetails);
-    return new NoOpAccessDecision(serverListIncludesAnyPatient(Sets.newHashSet(patientId)));
+    Set<String> patientIds = patientFinder.findPatientsFromParams(requestDetails);
+    Set<String> patientQueries = Sets.newHashSet();
+    patientIds.forEach(patientId -> patientQueries.add(String.format("Patient/%s", patientId)));
+    return new NoOpAccessDecision(serverListIncludesAllPatients(patientQueries));
   }
 
   private AccessDecision checkNonPatientAccessInUpdate(
@@ -249,10 +253,10 @@ public class ListAccessChecker implements AccessChecker {
         "Expected either PATCH or PUT!");
 
     // We do not allow direct resource PUT/PATCH, so Patient ID must be returned
-    String patientId = patientFinder.findPatientFromParams(requestDetails);
+    Set<String> patientIds = patientFinder.findPatientsFromParams(requestDetails);
     Set<String> patientQueries = Sets.newHashSet();
     // Escaping is not needed here as the set elements will be escaped later.
-    patientQueries.add(String.format("Patient/%s", patientId));
+    patientIds.forEach(patientId -> patientQueries.add(String.format("Patient/%s", patientId)));
 
     Set<String> patientSet = Sets.newHashSet();
     if (updateMethod == RequestTypeEnum.PATCH) {
@@ -327,6 +331,7 @@ public class ListAccessChecker implements AccessChecker {
 
     Set<String> patientsToCreate = Sets.newHashSet();
     Set<String> patientsToUpdate = Sets.newHashSet();
+    Set<String> patientsToDelete = patientsInBundleUnfiltered.getDeletedPatients();
 
     for (String patientId : patientsInBundleUnfiltered.getUpdatedPatients()) {
       if (!patientsExist(patientId)) {
@@ -342,7 +347,8 @@ public class ListAccessChecker implements AccessChecker {
 
     Set<String> patientQueries = Sets.newHashSet();
     for (Set<String> patientRefSet : patientsInBundleUnfiltered.getReferencedPatients()) {
-      if (Collections.disjoint(patientRefSet, patientsToCreate)) {
+      if (Collections.disjoint(patientRefSet, patientsToCreate)
+          && Collections.disjoint(patientRefSet, patientsToDelete)) {
         String orQuery = queryBuilder(patientRefSet, "Patient/", ",");
         patientQueries.add(orQuery);
       }
@@ -350,6 +356,13 @@ public class ListAccessChecker implements AccessChecker {
 
     if (!patientsToUpdate.isEmpty()) {
       for (String eachPatient : patientsToUpdate) {
+        String andQuery = String.format("Patient/%s", eachPatient);
+        patientQueries.add(andQuery);
+      }
+    }
+
+    if (!patientsToDelete.isEmpty()) {
+      for (String eachPatient : patientsToDelete) {
         String andQuery = String.format("Patient/%s", eachPatient);
         patientQueries.add(andQuery);
       }

--- a/plugins/src/main/java/com/google/fhir/gateway/plugin/PatientAccessChecker.java
+++ b/plugins/src/main/java/com/google/fhir/gateway/plugin/PatientAccessChecker.java
@@ -119,17 +119,21 @@ public class PatientAccessChecker implements AccessChecker {
     return processCreate(requestDetails);
   }
 
+  private Boolean validatePatientIds(Set<String> patientIds) {
+    return patientIds.size() == 1 && authorizedPatientId.equals(patientIds.iterator().next());
+  }
+
   private AccessDecision processRead(RequestDetailsReader requestDetails) {
-    String patientId = patientFinder.findPatientFromParams(requestDetails);
+    Set<String> patientIds = patientFinder.findPatientsFromParams(requestDetails);
     return new NoOpAccessDecision(
-        authorizedPatientId.equals(patientId)
+        validatePatientIds(patientIds)
             && smartScopeChecker.hasPermission(requestDetails.getResourceName(), Permission.READ));
   }
 
   private AccessDecision processSearch(RequestDetailsReader requestDetails) {
-    String patientId = patientFinder.findPatientFromParams(requestDetails);
+    Set<String> patientIds = patientFinder.findPatientsFromParams(requestDetails);
     return new NoOpAccessDecision(
-        authorizedPatientId.equals(patientId)
+        validatePatientIds(patientIds)
             && smartScopeChecker.hasPermission(
                 requestDetails.getResourceName(), Permission.SEARCH));
   }
@@ -159,9 +163,9 @@ public class PatientAccessChecker implements AccessChecker {
       return NoOpAccessDecision.accessDenied();
     }
     // TODO(https://github.com/google/fhir-access-proxy/issues/63):Support direct resource deletion.
-    String patientId = patientFinder.findPatientFromParams(requestDetails);
+    Set<String> patientIds = patientFinder.findPatientsFromParams(requestDetails);
     return new NoOpAccessDecision(
-        authorizedPatientId.equals(patientId)
+        validatePatientIds(patientIds)
             && smartScopeChecker.hasPermission(
                 requestDetails.getResourceName(), Permission.DELETE));
   }
@@ -169,8 +173,8 @@ public class PatientAccessChecker implements AccessChecker {
   private AccessDecision checkNonPatientAccessInUpdate(
       RequestDetailsReader requestDetails, RequestTypeEnum updateMethod) {
     // We do not allow direct resource PUT/PATCH, so Patient ID must be returned
-    String patientId = patientFinder.findPatientFromParams(requestDetails);
-    if (!patientId.equals(authorizedPatientId)) {
+    Set<String> referencedPatientIds = patientFinder.findPatientsFromParams(requestDetails);
+    if (!validatePatientIds(referencedPatientIds)) {
       return NoOpAccessDecision.accessDenied();
     }
 

--- a/plugins/src/test/java/com/google/fhir/gateway/plugin/AccessCheckerTestBase.java
+++ b/plugins/src/test/java/com/google/fhir/gateway/plugin/AccessCheckerTestBase.java
@@ -350,6 +350,17 @@ public abstract class AccessCheckerTestBase {
     testInstance.checkAccess(requestMock).canAccess();
   }
 
+  @Test
+  public void canAccessPatientWithIdSearch() {
+    when(requestMock.getResourceName()).thenReturn("Patient");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
+    Map<String, String[]> params = Maps.newHashMap();
+    params.put("_id", new String[] {PATIENT_AUTHORIZED});
+    when(requestMock.getParameters()).thenReturn(params);
+    AccessChecker testInstance = getInstance();
+    testInstance.checkAccess(requestMock).canAccess();
+  }
+
   @Test(expected = InvalidRequestException.class)
   public void canAccessSearchReverseChaining() {
     when(requestMock.getResourceName()).thenReturn("Observation");

--- a/plugins/src/test/java/com/google/fhir/gateway/plugin/PatientAccessCheckerTest.java
+++ b/plugins/src/test/java/com/google/fhir/gateway/plugin/PatientAccessCheckerTest.java
@@ -216,4 +216,15 @@ public class PatientAccessCheckerTest extends AccessCheckerTestBase {
     AccessChecker testInstance = getInstance();
     assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(false));
   }
+
+  @Test
+  public void canAccessGetObservationMultipleSubjectsUnauthorized() {
+    when(requestMock.getResourceName()).thenReturn("Observation");
+    when(requestMock.getRequestType()).thenReturn(RequestTypeEnum.GET);
+    when(requestMock.getParameters())
+        .thenReturn(
+            Map.of("subject", new String[] {PATIENT_AUTHORIZED + "," + PATIENT_NON_AUTHORIZED}));
+    AccessChecker testInstance = getInstance();
+    assertThat(testInstance.checkAccess(requestMock).canAccess(), equalTo(false));
+  }
 }

--- a/plugins/src/test/resources/bundle_transaction_delete_multiple_patient.json
+++ b/plugins/src/test/resources/bundle_transaction_delete_multiple_patient.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "request": {
+        "method": "DELETE",
+        "url": "Patient?_id=be92a43f-de46-affa-b131-bbf9eea51140,420e791b-e419-c19b-3144-29e101c2c12f"
+      }
+    }
+  ]
+}

--- a/plugins/src/test/resources/bundle_transaction_get_non_patient_multiple_authorized.json
+++ b/plugins/src/test/resources/bundle_transaction_get_non_patient_multiple_authorized.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Bundle",
+  "type": "transaction",
+  "entry": [
+    {
+      "request": {
+        "method": "GET",
+        "url": "Encounter?patient=be92a43f-de46-affa-b131-bbf9eea51140,420e791b-e419-c19b-3144-29e101c2c12f"
+      }
+    }
+  ]
+}

--- a/server/src/main/java/com/google/fhir/gateway/PatientFinderImp.java
+++ b/server/src/main/java/com/google/fhir/gateway/PatientFinderImp.java
@@ -120,7 +120,6 @@ public final class PatientFinderImp implements PatientFinder {
     String[] patientResources = delimitedString.trim().split(",");
     Set<String> patients =
         Arrays.stream(patientResources)
-            .distinct()
             .map(
                 resource -> {
                   // Making sure that we extract the actual ID without any resource type or URL.
@@ -170,9 +169,7 @@ public final class PatientFinderImp implements PatientFinder {
       IIdType referenceElement = new Reference(resourceUri.getPath()).getReferenceElement();
       if (FhirUtil.isSameResourceType(referenceElement.getResourceType(), ResourceType.Patient)) {
         String patientId = FhirUtil.checkIdOrFail(referenceElement.getIdPart());
-        if (patientId != null) {
-          return ImmutableSet.of(patientId);
-        }
+        return ImmutableSet.of(patientId);
       }
 
       // Reference is not created for URLs without an ID as a path parameter, hence an explicit
@@ -233,7 +230,6 @@ public final class PatientFinderImp implements PatientFinder {
           logger,
           "Direct resource fetch is only supported for Patient; use search for " + resourceName,
           InvalidRequestException.class);
-      return null;
     }
     Map<String, String[]> queryParams = requestDetails.getParameters();
     Set<String> patientIds = checkParamsAndFindPatientIds(resourceName, queryParams);

--- a/server/src/main/java/com/google/fhir/gateway/interfaces/PatientFinder.java
+++ b/server/src/main/java/com/google/fhir/gateway/interfaces/PatientFinder.java
@@ -26,11 +26,11 @@ public interface PatientFinder {
    * patient can be inferred from query parameters.
    *
    * @param requestDetails the request
-   * @return the id of the patient that this query belongs to or null if it cannot be inferred.
+   * @return the ids of the patients that this query belongs to or null if it cannot be inferred.
    * @throws InvalidRequestException for various reasons when unexpected parameters or content are
    *     encountered. Callers are expected to deny access when this happens.
    */
-  String findPatientFromParams(RequestDetailsReader requestDetails);
+  Set<String> findPatientsFromParams(RequestDetailsReader requestDetails);
 
   /**
    * Find all patients referenced or updated in a Bundle.

--- a/server/src/main/java/com/google/fhir/gateway/interfaces/PatientFinder.java
+++ b/server/src/main/java/com/google/fhir/gateway/interfaces/PatientFinder.java
@@ -19,6 +19,7 @@ import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import com.google.fhir.gateway.BundlePatients;
 import java.util.Set;
 import org.hl7.fhir.r4.model.Bundle;
+import org.jetbrains.annotations.NotNull;
 
 public interface PatientFinder {
   /**
@@ -31,6 +32,7 @@ public interface PatientFinder {
    * @throws InvalidRequestException for various reasons when unexpected parameters or content are
    *     encountered. Callers are expected to deny access when this happens.
    */
+  @NotNull
   Set<String> findPatientsFromParams(RequestDetailsReader requestDetails);
 
   /**

--- a/server/src/main/java/com/google/fhir/gateway/interfaces/PatientFinder.java
+++ b/server/src/main/java/com/google/fhir/gateway/interfaces/PatientFinder.java
@@ -26,7 +26,8 @@ public interface PatientFinder {
    * patient can be inferred from query parameters.
    *
    * @param requestDetails the request
-   * @return the ids of the patients that this query belongs to or null if it cannot be inferred.
+   * @return the ids of the patients that this query belongs to or an empty set if it cannot be
+   *     inferred.
    * @throws InvalidRequestException for various reasons when unexpected parameters or content are
    *     encountered. Callers are expected to deny access when this happens.
    */


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->

## Description of what I changed
Addresses issue #45 

- Support for extracting patient IDs in `/Patient` path with `_id` query parameter
- Support for extracting multiple patient IDs for other resource paths when the query parameter values have comma delimited patient IDs

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:
After the changes, I performed the operation to fetch multiple patient by using the `_id` query parameter and I got a successful response:
Request: `curl -X GET -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-H "Content-Type: application/json; charset=utf-8" \
'http://localhost:8081/Patient?_id=c301c100-e9af-11ed-a05b-0242ac120003,c301c434-e9af-11ed-a05b-0242ac120003'`


Response is : `{
  "resourceType": "Bundle",
  "id": "d476b15b-57ad-40a6-b359-7dabbd56c9be",
  "meta": {
    "lastUpdated": "2023-05-03T13:28:05.681+00:00"
  },
  "type": "searchset",
  "total": 2,
  "link": [ {
    "relation": "self",
    "url": "http://localhost:8081/Patient?_id=c301c100-e9af-11ed-a05b-0242ac120003%2Cc301c434-e9af-11ed-a05b-0242ac120003"
  } ],
  "entry": [ {
    "fullUrl": "http://localhost:8081/Patient/c301c100-e9af-11ed-a05b-0242ac120003",
    "resource": {
      "resourceType": "Patient",
      "id": "c301c100-e9af-11ed-a05b-0242ac120003",
      "meta": {
        "versionId": "1",
        "lastUpdated": "2023-05-03T12:47:38.246+00:00",
        "source": "#S2O1lgkQQJC4ETFq"
      },
      "text": {
        "status": "generated",
        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n\t\t\t<p>ID: test0122</p>\n\t\t\t<p>Name: Hanako Yamada</p>\n\t\t\t<p>Telephone: 06-1234-5678</p>\n\t\t\t<p>Gender: female</p>\n\t\t\t<p>BirthDate: 1981-01-23</p>\n\t\t</div>"
      },
      "identifier": [ {
        "system": "http://test.com",
        "value": "test0122"
      } ],
      "name": [ {
        "family": "Yamamoto",
        "given": [ "Hanakoooo" ]
      } ],
      "telecom": [ {
        "system": "phone",
        "value": "07-1234-5678"
      } ],
      "gender": "male",
      "birthDate": "1989-01-15"
    },
    "search": {
      "mode": "match"
    }
  }, {
    "fullUrl": "http://localhost:8081/Patient/c301c434-e9af-11ed-a05b-0242ac120003",
    "resource": {
      "resourceType": "Patient",
      "id": "c301c434-e9af-11ed-a05b-0242ac120003",
      "meta": {
        "versionId": "1",
        "lastUpdated": "2023-05-03T12:50:41.405+00:00",
        "source": "#Z3XUFIgorG3lSVXT"
      },
      "text": {
        "status": "generated",
        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><div class=\"hapiHeaderText\">TE <b>POTE </b></div><table class=\"hapiPropertyTable\"><tbody><tr><td>Identifier</td><td>002</td></tr><tr><td>Address</td><td><span>3300 Washtenaw </span><br/><span>Ann Harbor </span><span>MI </span><span>USA </span></td></tr></tbody></table></div>"
      },
      "identifier": [ {
        "system": "http://example.org",
        "value": "002"
      } ],
      "name": [ {
        "use": "official",
        "family": "POTE",
        "given": [ "TE" ]
      } ],
      "telecom": [ {
        "system": "phone",
        "value": "(03) 2019 1114",
        "use": "home"
      } ],
      "gender": "male",
      "address": [ {
        "use": "home",
        "text": "3300 Washtenaw Ann Harbor, MI 48104, USA",
        "line": [ "3300 Washtenaw" ],
        "city": "Ann Harbor",
        "state": "MI",
        "postalCode": "48104",
        "country": "USA"
      } ]
    },
    "search": {
      "mode": "match"
    }
  } ]
} `

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
