### PR TITLE
Refactor GZIP encoding check

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -367,7 +367,7 @@ The mapping from resources to patients is done through the
 [patient compartment](https://www.hl7.org/fhir/compartmentdefinition-patient.html)
 definition. Note that we can still access many resources in one query; in
 particular through
-[Patient/ID/$everything](https://hl7.org/fhir/patient-operation-everything.html)
+[Patient/ID/\$everything](https://hl7.org/fhir/patient-operation-everything.html)
 queries, we can fetch all updates for a single patient.
 
 This approach helps support both the **flexible-access-control** and
@@ -553,10 +553,10 @@ In the main text, we refer to these examples by "all-patients",
 ## Notes
 
 [^1]:
-    The simplified
-    [Implicit](https://smilecdr.com/docs/smart/smart_on_fhir_authorization_flows.html#launch-flow-implicit-grant)
-    flow could work for our use-case too but that has important security
-    shortcomings. For example, it exposes access_token in URLs which can leak
-    through browser history. Another more important shortcoming is that we
-    cannot implement PKCE in the Implicit flow as the access_token is directly
-    returned in the first request.
+  The simplified
+  [Implicit](https://smilecdr.com/docs/smart/smart_on_fhir_authorization_flows.html#launch-flow-implicit-grant)
+  flow could work for our use-case too but that has important security
+  shortcomings. For example, it exposes access_token in URLs which can leak
+  through browser history. Another more important shortcoming is that we cannot
+  implement PKCE in the Implicit flow as the access_token is directly returned
+  in the first request.

--- a/server/src/main/java/com/google/fhir/gateway/BearerAuthorizationInterceptor.java
+++ b/server/src/main/java/com/google/fhir/gateway/BearerAuthorizationInterceptor.java
@@ -211,7 +211,7 @@ public class BearerAuthorizationInterceptor {
     if (acceptEncodingValue == null) {
       return false;
     }
-    return GZIP_ENCODING_VALUE.equalsIgnoreCase(acceptEncodingValue);
+    return acceptEncodingValue.contains(GZIP_ENCODING_VALUE);
   }
 
   /**

--- a/server/src/main/java/com/google/fhir/gateway/BearerAuthorizationInterceptor.java
+++ b/server/src/main/java/com/google/fhir/gateway/BearerAuthorizationInterceptor.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.Writer;
+import java.util.Locale;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -211,7 +212,7 @@ public class BearerAuthorizationInterceptor {
     if (acceptEncodingValue == null) {
       return false;
     }
-    return acceptEncodingValue.contains(GZIP_ENCODING_VALUE);
+    return acceptEncodingValue.toLowerCase(Locale.ENGLISH).contains(GZIP_ENCODING_VALUE);
   }
 
   /**

--- a/server/src/test/java/com/google/fhir/gateway/BearerAuthorizationInterceptorTest.java
+++ b/server/src/test/java/com/google/fhir/gateway/BearerAuthorizationInterceptorTest.java
@@ -337,4 +337,42 @@ public class BearerAuthorizationInterceptorTest {
     assertThat(
         proxyServletResponseMock.getHeader("Content-Encoding".toLowerCase()), equalTo("gzip"));
   }
+
+  @Test
+  public void shouldSendGzippedResponseWhenRequestedCaseInsensitive() throws IOException {
+    testInstance = createTestInstance(true, null);
+    String responseJson = "{\"resourceType\": \"Bundle\"}";
+    when(requestMock.getHeader("Authorization")).thenReturn("Bearer ANYTHING");
+    when(requestMock.getHeader("Accept-Encoding".toLowerCase())).thenReturn("GZIP");
+    when(requestMock.getServer()).thenReturn(serverMock);
+    ServletRestfulResponse proxyResponseMock = new ServletRestfulResponse(requestMock);
+    when(requestMock.getResponse()).thenReturn(proxyResponseMock);
+    HttpServletResponse proxyServletResponseMock = new MockHttpServletResponse();
+    when(requestMock.getServletResponse()).thenReturn(proxyServletResponseMock);
+    TestUtil.setUpFhirResponseMock(fhirResponseMock, responseJson);
+
+    testInstance.authorizeRequest(requestMock);
+
+    assertThat(
+        proxyServletResponseMock.getHeader("Content-Encoding".toLowerCase()), equalTo("gzip"));
+  }
+
+  @Test
+  public void shouldSendGzippedResponseWhenRequestedMultipleEncodingFormats() throws IOException {
+    testInstance = createTestInstance(true, null);
+    String responseJson = "{\"resourceType\": \"Bundle\"}";
+    when(requestMock.getHeader("Authorization")).thenReturn("Bearer ANYTHING");
+    when(requestMock.getHeader("Accept-Encoding".toLowerCase())).thenReturn("gzip, deflate, br");
+    when(requestMock.getServer()).thenReturn(serverMock);
+    ServletRestfulResponse proxyResponseMock = new ServletRestfulResponse(requestMock);
+    when(requestMock.getResponse()).thenReturn(proxyResponseMock);
+    HttpServletResponse proxyServletResponseMock = new MockHttpServletResponse();
+    when(requestMock.getServletResponse()).thenReturn(proxyServletResponseMock);
+    TestUtil.setUpFhirResponseMock(fhirResponseMock, responseJson);
+
+    testInstance.authorizeRequest(requestMock);
+
+    assertThat(
+        proxyServletResponseMock.getHeader("Content-Encoding".toLowerCase()), equalTo("gzip"));
+  }
 }


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->

## Description of what I changed

When determining whether to apply the Gzip header [our condition](https://github.com/google/fhir-gateway/blob/4376a58fa2e1316050177c3bb3d206f1f1fcd7c1/server/src/main/java/com/google/fhir/gateway/BearerAuthorizationInterceptor.java#L214) checks for an exact match in the header value passed for **Accept-Encoding**. This is limiting since various clients by default supply multiple comma separated values _e.g. Accept-Encoding: gzip, deflate, br_ and the server responds according to configuration. 

A better approach would be to use the `String.contains` method to check for the occurrence of the GZip literal.

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Please replace this with a description of how you tested your PR beyond the
automated e2e/unit tests.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
