### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Run tests and collect coverage
       run: mvn -B test
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         # To find this token, and how it is stored in the repo, see:
         # https://docs.codecov.com/docs/adding-the-codecov-token


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `codecov/codecov-action` | [`v4`](https://github.com/codecov/codecov-action/releases/tag/v4) | [`v5`](https://github.com/codecov/codecov-action/releases/tag/v5) | [Release](https://github.com/codecov/codecov-action/releases/tag/v5) | codecov.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
