### PR TITLE
Fixes null cases for JwtUtil.getDecodedJwtFromRequestDetails

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,10 +232,12 @@ starting from this
 example.
 
 # Contributions
+
 This is an open-source project and we welcome contributions. Our development
 process is also open. We use GitHub issues and review processes. If you are
 working on a feature or an issue, please comment on that GitHub issue to
 communicate with other developers. It would also be great to attend our weekly
 developers' calls on Tuesdays; here are the details:
+
 - **When**: Tuesdays at 10 AM Eastern Time (Toronto)
 - **Where**: Virtual at https://meet.google.com/ago-nmcc-oed

--- a/server/src/main/java/com/google/fhir/gateway/JwtUtil.java
+++ b/server/src/main/java/com/google/fhir/gateway/JwtUtil.java
@@ -21,6 +21,7 @@ import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.google.fhir.gateway.interfaces.RequestDetailsReader;
+import javax.annotation.Nullable;
 import org.apache.http.HttpHeaders;
 
 public class JwtUtil {
@@ -51,9 +52,24 @@ public class JwtUtil {
     return claim;
   }
 
+  /**
+   * Decodes the JWT carried in the {@code Authorization} header of the given request. The signature
+   * is not verified here; see {@link TokenVerifier}.
+   *
+   * @param requestDetails the request to read the header from; may be null
+   * @return the decoded JWT, or null if {@code requestDetails} is null, the request carries no
+   *     {@code Authorization} header, or that header does not use the {@code Bearer} scheme. A
+   *     missing header is not an error: the Gateway serves some endpoints, such as the
+   *     CapabilityStatement at {@code /metadata}, without requiring a token. Callers must handle a
+   *     null return.
+   */
+  @Nullable
   public static DecodedJWT getDecodedJwtFromRequestDetails(RequestDetailsReader requestDetails) {
     if (requestDetails == null) return null;
     String authHeader = requestDetails.getHeader(HttpHeaders.AUTHORIZATION);
+    if (authHeader == null || !authHeader.startsWith(TokenVerifier.BEARER_PREFIX)) {
+      return null;
+    }
     String bearerToken = authHeader.substring(TokenVerifier.BEARER_PREFIX.length());
     return JWT.decode(bearerToken);
   }

--- a/server/src/main/java/com/google/fhir/gateway/interfaces/AccessDecision.java
+++ b/server/src/main/java/com/google/fhir/gateway/interfaces/AccessDecision.java
@@ -82,6 +82,11 @@ public interface AccessDecision {
     DecodedJWT decodedJWT;
     try {
       decodedJWT = JwtUtil.getDecodedJwtFromRequestDetails(request);
+      if (decodedJWT == null) {
+        // Unauthenticated request, e.g. the CapabilityStatement at /metadata, which the Gateway
+        // serves without a token. There is no actor to attribute an AuditEvent to.
+        return null;
+      }
       String name =
           JwtUtil.getClaimOrDefault(
               decodedJWT,

--- a/server/src/test/java/com/google/fhir/gateway/JwtUtilTest.java
+++ b/server/src/test/java/com/google/fhir/gateway/JwtUtilTest.java
@@ -58,9 +58,9 @@ public class JwtUtilTest {
   /**
    * Regression test: the Gateway serves endpoints such as the CapabilityStatement at {@code
    * /metadata} without requiring a token, so {@link
-   * com.google.fhir.gateway.interfaces.AccessDecision#getUserWho} reaches this method with no {@code
-   * Authorization} header whenever AuditEvent logging is enabled. That used to throw a {@link
-   * NullPointerException} mid-response.
+   * com.google.fhir.gateway.interfaces.AccessDecision#getUserWho} reaches this method with no
+   * {@code Authorization} header whenever AuditEvent logging is enabled. That used to throw a
+   * {@link NullPointerException} mid-response.
    */
   @Test
   public void getDecodedJwtFromRequestDetails_returnsNullWhenNoAuthorizationHeader() {

--- a/server/src/test/java/com/google/fhir/gateway/JwtUtilTest.java
+++ b/server/src/test/java/com/google/fhir/gateway/JwtUtilTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021-2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.fhir.gateway;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.when;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.google.fhir.gateway.interfaces.RequestDetailsReader;
+import org.apache.http.HttpHeaders;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JwtUtilTest {
+
+  private static final String SUBJECT = "test-subject";
+  private static final String ISSUER = "https://issuer.example.com/realms/test";
+
+  @Mock private RequestDetailsReader requestMock;
+
+  private static String signedToken() {
+    return JWT.create().withSubject(SUBJECT).withIssuer(ISSUER).sign(Algorithm.none());
+  }
+
+  @Test
+  public void getDecodedJwtFromRequestDetails_decodesBearerToken() {
+    when(requestMock.getHeader(HttpHeaders.AUTHORIZATION))
+        .thenReturn(TokenVerifier.BEARER_PREFIX + signedToken());
+
+    DecodedJWT decodedJWT = JwtUtil.getDecodedJwtFromRequestDetails(requestMock);
+
+    assertThat(decodedJWT, notNullValue());
+    assertThat(decodedJWT.getSubject(), equalTo(SUBJECT));
+    assertThat(decodedJWT.getIssuer(), equalTo(ISSUER));
+  }
+
+  /**
+   * Regression test: the Gateway serves endpoints such as the CapabilityStatement at {@code
+   * /metadata} without requiring a token, so {@link
+   * com.google.fhir.gateway.interfaces.AccessDecision#getUserWho} reaches this method with no {@code
+   * Authorization} header whenever AuditEvent logging is enabled. That used to throw a {@link
+   * NullPointerException} mid-response.
+   */
+  @Test
+  public void getDecodedJwtFromRequestDetails_returnsNullWhenNoAuthorizationHeader() {
+    when(requestMock.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn(null);
+
+    assertThat(JwtUtil.getDecodedJwtFromRequestDetails(requestMock), nullValue());
+  }
+
+  @Test
+  public void getDecodedJwtFromRequestDetails_returnsNullWhenSchemeIsNotBearer() {
+    when(requestMock.getHeader(HttpHeaders.AUTHORIZATION)).thenReturn("Basic dXNlcjpwYXNzd29yZA==");
+
+    assertThat(JwtUtil.getDecodedJwtFromRequestDetails(requestMock), nullValue());
+  }
+
+  @Test
+  public void getDecodedJwtFromRequestDetails_returnsNullWhenRequestIsNull() {
+    assertThat(JwtUtil.getDecodedJwtFromRequestDetails(null), nullValue());
+  }
+}


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->

## Description of what I changed

Closes https://github.com/ohs-foundation/fhir-gateway/issues/574

## E2E test

Manual testing was successful

TESTED:

Please replace this with a description of how you tested your PR beyond the
automated e2e/unit tests.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [ ] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [ ] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [ ] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [ ] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [ ] All new and existing **tests passed**.
- [ ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
